### PR TITLE
fix: correct codex-plugin's transcript parsing to match real rollout format

### DIFF
--- a/codex-plugin/src/transcript.test.ts
+++ b/codex-plugin/src/transcript.test.ts
@@ -3,9 +3,9 @@ import { extractLastUserPrompt } from "./transcript"
 import path from "path"
 import os from "os"
 
-// These test the parser's assumed schema, not a real Codex transcript — see
-// the "UNVERIFIED" comment in transcript.ts. If real Codex data turns out to
-// be shaped differently, these tests (and the parser) need updating together.
+// Fixtures match a real Codex rollout transcript's shape (verified against
+// an actual session) — payload.role/content, not entry.type like Claude
+// Code, and "input_text"/"output_text" content-block types, not "text".
 
 const tmpFiles: string[] = []
 
@@ -22,21 +22,35 @@ async function writeTranscript(lines: unknown[]): Promise<string> {
     return p
 }
 
-test("extracts a plain string content user message", async () => {
+function responseItem(payload: unknown) {
+    return { timestamp: "2026-07-28T00:00:00.000Z", type: "response_item", payload }
+}
+
+test("extracts a user message, ignoring developer instruction messages", async () => {
     const p = await writeTranscript([
-        { type: "user", message: { role: "user", content: "add a prime checker" } },
-        { type: "assistant", message: { role: "assistant", content: "done" } },
+        responseItem({ type: "message", role: "developer", content: [{ type: "input_text", text: "<system instructions>" }] }),
+        responseItem({ type: "message", role: "user", content: [{ type: "input_text", text: "add a prime checker" }] }),
+        responseItem({ type: "message", role: "assistant", content: [{ type: "output_text", text: "done" }] }),
     ])
     expect(await extractLastUserPrompt(p)).toBe("add a prime checker")
 })
 
 test("picks the LAST user message, not the first", async () => {
     const p = await writeTranscript([
-        { type: "user", message: { role: "user", content: "first prompt" } },
-        { type: "assistant", message: { role: "assistant", content: "ok" } },
-        { type: "user", message: { role: "user", content: "second prompt" } },
+        responseItem({ type: "message", role: "user", content: [{ type: "input_text", text: "first prompt" }] }),
+        responseItem({ type: "message", role: "assistant", content: [{ type: "output_text", text: "ok" }] }),
+        responseItem({ type: "message", role: "user", content: [{ type: "input_text", text: "second prompt" }] }),
     ])
     expect(await extractLastUserPrompt(p)).toBe("second prompt")
+})
+
+test("ignores non-message response_item entries (reasoning, custom_tool_call)", async () => {
+    const p = await writeTranscript([
+        responseItem({ type: "message", role: "user", content: [{ type: "input_text", text: "the real prompt" }] }),
+        { timestamp: "t", type: "response_item", payload: { type: "reasoning", id: "rs_1", summary: [] } },
+        { timestamp: "t", type: "response_item", payload: { type: "custom_tool_call", name: "exec", input: "ls" } },
+    ])
+    expect(await extractLastUserPrompt(p)).toBe("the real prompt")
 })
 
 test("returns empty string for a missing file rather than throwing", async () => {
@@ -45,7 +59,7 @@ test("returns empty string for a missing file rather than throwing", async () =>
 
 test("skips malformed lines instead of throwing", async () => {
     const p = path.join(os.tmpdir(), `codex-transcript-test-malformed-${Date.now()}.jsonl`)
-    await Bun.write(p, "not json\n" + JSON.stringify({ type: "user", message: { role: "user", content: "ok prompt" } }))
+    await Bun.write(p, "not json\n" + JSON.stringify(responseItem({ type: "message", role: "user", content: [{ type: "input_text", text: "ok prompt" }] })))
     tmpFiles.push(p)
     expect(await extractLastUserPrompt(p)).toBe("ok prompt")
 })

--- a/codex-plugin/src/transcript.ts
+++ b/codex-plugin/src/transcript.ts
@@ -1,13 +1,11 @@
-// UNVERIFIED — unlike claude-code-plugin's transcript parser (checked
-// against a real transcript.jsonl from an actual session), this one is only
-// modeled on Codex's hooks reference description ("the session transcript
-// file, if any") plus the reasonable assumption that it's shaped like Claude
-// Code's (both are JSONL conversation logs, and Codex's hook event names/
-// fields otherwise mirror Claude Code's closely). Model doesn't need to be
-// extracted here — Codex's hook input includes a `model` field directly
-// (unlike Claude Code), which index.ts reads straight from the hook payload.
-// Verify this against a real transcript.jsonl before relying on it in
-// production; never throws, so worst case the prompt just comes back empty.
+// Verified against a real Codex CLI rollout transcript (not just inferred
+// from the hooks reference). The actual shape is quite different from
+// Claude Code's:
+//   { "type": "response_item", "payload": { "type": "message", "role": "user" | "assistant" | "developer", "content": [{ "type": "input_text" | "output_text", "text": "..." }] } }
+// The role/content live under `payload`, not at the entry's top level, and
+// content-block types are "input_text"/"output_text" rather than "text".
+// "developer" entries (system/instruction messages Codex injects) must be
+// excluded — only "user" is the participant's actual prompt.
 export async function extractLastUserPrompt(transcriptPath: string): Promise<string> {
     try {
         const text = await Bun.file(transcriptPath).text()
@@ -24,13 +22,10 @@ export async function extractLastUserPrompt(transcriptPath: string): Promise<str
                 continue
             }
 
-            const role = (entry as { type?: string; message?: { role?: string } })?.type
-                ?? (entry as { message?: { role?: string } })?.message?.role
+            const payload = (entry as { payload?: { type?: string; role?: string; content?: unknown } })?.payload
+            if (!payload || payload.type !== "message" || payload.role !== "user") continue
 
-            if (role !== "user") continue
-
-            const content = (entry as { message?: { content?: unknown } })?.message?.content
-            const asText = contentToText(content)
+            const asText = contentToText(payload.content)
             if (asText) return asText
         }
     } catch {
@@ -46,7 +41,7 @@ function contentToText(content: unknown): string {
     if (Array.isArray(content)) {
         return content
             .filter((block): block is { type: string; text: string } =>
-                typeof block === "object" && block !== null && (block as { type?: string }).type === "text")
+                typeof block === "object" && block !== null && (block as { type?: string }).type === "input_text")
             .map(block => block.text)
             .join("\n")
     }


### PR DESCRIPTION
## Summary

`codex-plugin/src/transcript.ts` was flagged as unverified in #130 — it assumed Codex's `transcript_path` JSONL was shaped like Claude Code's. Real testing showed it isn't, and every real Codex Tasklet was silently getting an empty `prompt`.

Real shape (confirmed against an actual rollout transcript):
```json
{"type": "response_item", "payload": {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "..."}]}}
```
vs. what the parser assumed (Claude Code's shape):
```json
{"type": "user", "message": {"role": "user", "content": [{"type": "text", "text": "..."}]}}
```

Role/content live under `payload`, not the entry's top level, and content blocks use `input_text`/`output_text` instead of `text`. Also needed to exclude `"developer"`-role entries (Codex's injected system/instruction messages), which would otherwise be picked up as if they were the user's own prompt.

## Test plan

- [x] Unit tests updated to match the real schema (5 passing)
- [x] Verified directly against a real Codex CLI rollout transcript file — correctly extracts the actual prompt text
- [x] Redeployed `~/.codex/hooks.json` with the fixed build