### PR TITLE
ci: include claude-code-plugin and codex-plugin in release + build checks

### DIFF
--- a/.github/workflows/build-cc.yml
+++ b/.github/workflows/build-cc.yml
@@ -1,0 +1,32 @@
+name: Build Check (Claude Code plugin)
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'claude-code-plugin/**'
+
+jobs:
+  build-cc:
+    name: Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: claude-code-plugin
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Check Build
+        run: bun run build
+
+      - name: Run Tests
+        run: bun test

--- a/.github/workflows/build-codex.yml
+++ b/.github/workflows/build-codex.yml
@@ -1,0 +1,32 @@
+name: Build Check (Codex plugin)
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'codex-plugin/**'
+
+jobs:
+  build-codex:
+    name: Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: codex-plugin
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Check Build
+        run: bun run build
+
+      - name: Run Tests
+        run: bun test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,3 +130,55 @@ jobs:
           tag_name: ${{ needs.create-release.outputs.tag }}
           files: opencode-plugin/dist/tracybot-oc.js
 
+  # Builds and uploads Claude Code plugin to latest release
+  publish-cc:
+    name: Build & Upload Claude Code Plugin
+    needs: create-release
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: claude-code-plugin
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.create-release.outputs.tag }}
+
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - run: bun install
+      - run: bun run build
+
+      - name: Upload Claude Code Plugin Asset to Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.create-release.outputs.tag }}
+          files: claude-code-plugin/dist/tracybot-cc-hook.js
+
+  # Builds and uploads Codex plugin to latest release
+  publish-codex:
+    name: Build & Upload Codex Plugin
+    needs: create-release
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: codex-plugin
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.create-release.outputs.tag }}
+
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - run: bun install
+      - run: bun run build
+
+      - name: Upload Codex Plugin Asset to Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.create-release.outputs.tag }}
+          files: codex-plugin/dist/tracybot-codex-hook.js
+


### PR DESCRIPTION
## Summary

- `release.yml` only had jobs for `vscode-extension` and `opencode-plugin` — adds `publish-cc`/`publish-codex`, mirroring `publish-oc`'s pattern, so a release actually produces a downloadable build for the two newer plugins too.
- `build-cc.yml`/`build-codex.yml` add the same per-PR build-check `opencode-plugin` already has (`build-oc.yml`). Both also run `bun test` — opencode-plugin's workflow doesn't, since it has no test script, but the other two do. This is a direct follow-up to #131, where a wrong transcript-format assumption in `codex-plugin` wasn't caught until manual real-world testing; running its unit tests in CI is a small hedge against that happening again unnoticed.

## Test plan

- [x] Validated all three YAML files parse correctly
- [x] Structure mirrors the existing `opencode-plugin` jobs exactly (same actions, same bun setup), so behavior should be predictable