### PR TITLE
docs: update READMEs for Claude Code/Codex support and Research Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![License](https://img.shields.io/github/license/TracyTeam/tracybot?style=flat-square)](LICENSE) 
 [![VSC Extension Build](https://img.shields.io/github/actions/workflow/status/TracyTeam/tracybot/build-vs.yml?style=flat-square&logo=github&label=VSC%20Build)](https://github.com/TracyTeam/tracybot/actions/workflows/build-vs.yml) 
 [![OC Plugin Build](https://img.shields.io/github/actions/workflow/status/TracyTeam/tracybot/build-oc.yml?style=flat-square&logo=github&label=OC%20Build)](https://github.com/TracyTeam/tracybot/actions/workflows/build-oc.yml) 
+[![CC Plugin Build](https://img.shields.io/github/actions/workflow/status/TracyTeam/tracybot/build-cc.yml?style=flat-square&logo=github&label=CC%20Build)](https://github.com/TracyTeam/tracybot/actions/workflows/build-cc.yml) 
+[![Codex Plugin Build](https://img.shields.io/github/actions/workflow/status/TracyTeam/tracybot/build-codex.yml?style=flat-square&logo=github&label=Codex%20Build)](https://github.com/TracyTeam/tracybot/actions/workflows/build-codex.yml) 
 [![VS Code Marketplace Version](https://vsmarketplacebadges.dev/version-short/TracyTeam.tracybot-extension.svg?style=flat-square&logo=visual-studio-code)](https://marketplace.visualstudio.com/items?itemName=TracyTeam.tracybot-extension)
 
 ![Representative](./public/representative.png)
@@ -14,15 +16,20 @@ Tracybot is a tool that traces AI-generated code back to the prompts that create
 
 - **AI Traceability** - Map AI-generated lines of code back to their originating prompt
 - **Non-Invasive Storage** - Hidden Git commits and refs keep your history clean
-- **Seamless Integration** - Works with OpenCode CLI and Visual Studio Code
+- **Seamless Integration** - Works with OpenCode CLI, Claude Code, Codex CLI, and Visual Studio Code
 - **Audit Trail** - Review AI interactions to verify, debug, or understand code origins
 - **Team Sync** - Push traces to remote for team collaboration
+- **Research Mode** - Optional, opt-in sharing of your Tasklet history for a research study on AI-assisted coding behavior — see [docs/research-mode.md](./docs/research-mode.md)
 
 ## Supported Agents and Editors
 
 ### Supported Agents
-- **OpenCode CLI** — Install the [opencode-plugin](./opencode-plugin/README.md) to automatically record snapshots during AI interactions. 
+- **OpenCode CLI** — Install the [opencode-plugin](./opencode-plugin/README.md) to automatically record snapshots during AI interactions.
 Requires OpenCode CLI to be installed - https://opencode.ai
+- **Claude Code** — Install the [claude-code-plugin](./claude-code-plugin/README.md) to automatically record snapshots during AI interactions.
+Requires Claude Code to be installed.
+- **Codex CLI** — Install the [codex-plugin](./codex-plugin/README.md) to automatically record snapshots during AI interactions.
+Requires Codex CLI to be installed.
 
 ### Supported Editors
 - **VS Code** — Install the [vscode-extension](./vscode-extension/README.md) to view AI blame information. 
@@ -33,7 +40,7 @@ Available on the [VS Code Marketplace](https://marketplace.visualstudio.com/item
 
 ### 1. Install the VS Code Extension
 
-This is the entry point to Tracybot. The extension can open AI Blame, prompt to initialize Tracybot in the current repository, and offer to install the OpenCode plugin.
+This is the entry point to Tracybot. The extension can open AI Blame, prompt to initialize Tracybot in the current repository, and offer to install an agent plugin.
 
 You can install the extension directly within VS Code:
 1. Open VS Code and go to the **Extensions** view (`Ctrl+Shift+X` or `Cmd+Shift+X`).
@@ -59,26 +66,29 @@ Requirements:
 - Python 3 available as `python3` or `python`
 - An `origin` remote is optional; it is only needed for syncing Tracy refs and notes with a remote
 
-### 3. Install the OpenCode Plugin
+### 3. Install an Agent Plugin
 
-If the VS Code extension is installed, it will prompt you to install the OpenCode plugin when it is missing.
+If the VS Code extension is installed, it will prompt you to install the OpenCode plugin when it is missing. Whichever agent you use, install its matching plugin:
 
-You can install it either:
-- Globally at `~/.config/opencode/plugin/tracybot-oc.js`
-- Per project at `.opencode/plugin/tracybot-oc.js`
+- **OpenCode** — [opencode-plugin](./opencode-plugin/README.md), installed at `~/.config/opencode/plugin/tracybot-oc.js` (global) or `.opencode/plugin/tracybot-oc.js` (per project)
+- **Claude Code** — [claude-code-plugin](./claude-code-plugin/README.md), installed via hooks in `~/.claude/settings.json`
+- **Codex CLI** — [codex-plugin](./codex-plugin/README.md), installed via hooks in `~/.codex/hooks.json`
 
+You can install more than one if you use multiple agents — Tracybot records which one produced each Tasklet.
 
 ### 4. Start Using AI Blame
 
-After OpenCode makes changes in an initialized repository, Tracybot records snapshots automatically. Click `AI Blame` in VS Code to inspect the prompt history behind the current file.
+After your agent makes changes in an initialized repository, Tracybot records snapshots automatically. Click `AI Blame` in VS Code to inspect the prompt history behind the current file.
 
 ## Architecture
 
-Tracybot consists of three components that work together:
+Tracybot consists of these components working together:
 
-- **[opencode-plugin](./opencode-plugin/README.md)** - Plugin for opencode CLI that records snapshots during AI interactions
-- **[vscode-extension](./vscode-extension/README.md)** - VS Code extension to view AI blame information
-- **[tracybot-tracking](./tracking/README.md)** - Git hooks and scripts for state tracking using hidden commits and synced git notes
+- **[opencode-plugin](./opencode-plugin/README.md)** - Plugin for OpenCode CLI that records snapshots during AI interactions
+- **[claude-code-plugin](./claude-code-plugin/README.md)** - Hooks for Claude Code that record snapshots during AI interactions
+- **[codex-plugin](./codex-plugin/README.md)** - Hooks for Codex CLI that record snapshots during AI interactions
+- **[vscode-extension](./vscode-extension/README.md)** - VS Code extension to view AI blame information, and the opt-in Research Mode (see [docs/research-mode.md](./docs/research-mode.md))
+- **[tracybot-tracking](./tracking/README.md)** - Git hooks and scripts for state tracking using hidden commits and synced git notes, shared by all three agent plugins
 
 More information, including the requirements that resulted in these architectural decisions, are on the [wiki](https://github.com/TracyTeam/tracybot/wiki/Architecture).
 
@@ -89,13 +99,13 @@ More information, including the requirements that resulted in these architectura
 **No AI blame information showing**
 - Ensure the repository was initialized with `init.py`
 - Verify VS Code extension is installed
-- Check that OpenCode has already produced tracked changes in this repository
+- Check that your agent (OpenCode, Claude Code, or Codex) has already produced tracked changes in this repository
 
 **Snapshots not being created**
-- Check that the OpenCode plugin is installed and loaded
+- Check that the matching agent plugin is installed and loaded
 - Verify Tracybot was initialized successfully in the repository
 - Verify Git hooks are installed under `.git/hooks/`
-- Check for errors in the OpenCode output
+- Check for errors in the agent's output
 
 **Push sync not working**
 - Ensure an `origin` remote is configured
@@ -132,9 +142,30 @@ bun run deploy
 
 `bun run deploy` builds the plugin and installs it into the global OpenCode plugin directory.
 
+### Work on the Claude Code Plugin
+
+```bash
+cd claude-code-plugin
+bun install
+bun run deploy
+```
+
+`bun run deploy` builds the plugin and adds its hooks to `~/.claude/settings.json`, without touching any hooks you already have configured there.
+
+### Work on the Codex Plugin
+
+```bash
+cd codex-plugin
+bun install
+bun run deploy
+```
+
+`bun run deploy` builds the plugin and adds its hooks to `~/.codex/hooks.json`, without touching any hooks you already have configured there.
+
 ### Manual Installation from Release Assets
 
 If you are testing packaging or release artifacts manually:
 
 1. Download `vscode-extension.vsix` from the [latest release](https://github.com/TracyTeam/tracybot/releases/latest) and install it with `code --install-extension vscode-extension.vsix` or VS Code's `Install from VSIX...` action.
 2. Download `tracybot-oc.js` from the same release and place it in either `~/.config/opencode/plugin/` or `<repo>/.opencode/plugin/`.
+3. Download `tracybot-cc-hook.js` (Claude Code) or `tracybot-codex-hook.js` (Codex) from the same release, and register hooks pointing at it in `~/.claude/settings.json` or `~/.codex/hooks.json` respectively — see each plugin's README for the exact hook configuration.

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -45,7 +45,7 @@ irm https://raw.githubusercontent.com/TracyTeam/tracybot/main/vscode-extension/i
 
 1. Open a Git repository in VS Code.
 2. If Tracybot has not been initialized in that repository yet, the extension offers to run initialization for you.
-3. If the OpenCode plugin is missing, the extension offers to install it globally or for the current workspace.
+3. If the OpenCode plugin is missing, the extension offers to install it globally or for the current workspace. Using Claude Code or Codex CLI instead? Install [claude-code-plugin](https://github.com/TracyTeam/tracybot/tree/main/claude-code-plugin) or [codex-plugin](https://github.com/TracyTeam/tracybot/tree/main/codex-plugin) — Tracybot records which agent produced each Tasklet either way.
 4. Click the `AI Blame` status bar item, or run `Tracybot: Open AI Blame window` from the command palette.
 
 ## Requirements
@@ -60,10 +60,15 @@ Node.js and npm are only required for developing the extension from source.
 Displays the history of AI-generated code changes in a dedicated editor tab. The `AI Blame` button is shown in the right side of the VS Code status bar.
 
 - **Highlighted lines**: Each file highlights AI-generated lines
-- **Tasklet details**: Click on any highlighted line to see the originating tasklet
-  - A tasklet consists of 0 or more plan prompts followed by a build prompt and contains both user prompts and AI responses
+- **Tasklet details**: Click on any highlighted line to see the originating tasklet, including which agent (OpenCode, Claude Code, or Codex) produced it
+  - For OpenCode, a tasklet consists of 0 or more plan prompts followed by a build prompt
+  - Claude Code and Codex have no separate planning stage, so their tasklets are a single prompt/response turn
   - A tasklet Zod schema is available under `src/history/types.ts`
 - **File history**: View all tasklets that modified the current version of the file
+
+## Research Mode
+
+An optional, opt-in feature to share your Tasklet history for a research study on AI-assisted coding behavior. Off by default, and can be disabled at any time from Settings. See [docs/research-mode.md](https://github.com/TracyTeam/tracybot/blob/main/docs/research-mode.md) in the main repository for what's collected and how consent works.
 
 ## Keybindings
 


### PR DESCRIPTION
## Summary

Both READMEs still described the original OpenCode-only, Research-Mode-less Tracybot, even though #130/#131 shipped both a while ago — `vscode-extension/README.md` in particular is what renders as the Marketplace listing's Details tab, so this was directly user-facing stale documentation.

- Root `README.md`: Features, Supported Agents, Architecture, Troubleshooting, and Getting Started sections now cover all three agent plugins; Research Mode added to the feature list; CI build-status badges added for the two new plugins; Manual Installation section covers the two new release assets.
- `vscode-extension/README.md`: notes Claude Code/Codex as alternatives to OpenCode, adds a Research Mode section (previously not mentioned on the Marketplace page at all), updates the Tasklet description for agents without a Plan/Build split.

## Test plan

- [x] Read through both files end-to-end for internal consistency after edits
- N/A — docs-only change, no code affected