### PR TITLE
feat: auto-detect and auto-install Claude Code/Codex plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Available on the [VS Code Marketplace](https://marketplace.visualstudio.com/item
 
 ### 1. Install the VS Code Extension
 
-This is the entry point to Tracybot. The extension can open AI Blame, prompt to initialize Tracybot in the current repository, and offer to install an agent plugin.
+This is the entry point to Tracybot. The extension can open AI Blame, prompt to initialize Tracybot in the current repository, and automatically installs plugins for any supported agent it detects on your machine.
 
 You can install the extension directly within VS Code:
 1. Open VS Code and go to the **Extensions** view (`Ctrl+Shift+X` or `Cmd+Shift+X`).
@@ -66,15 +66,15 @@ Requirements:
 - Python 3 available as `python3` or `python`
 - An `origin` remote is optional; it is only needed for syncing Tracy refs and notes with a remote
 
-### 3. Install an Agent Plugin
+### 3. Agent Plugins Install Automatically
 
-If the VS Code extension is installed, it will prompt you to install the OpenCode plugin when it is missing. Whichever agent you use, install its matching plugin:
+If the VS Code extension is installed, it detects whichever supported agent CLIs you already have (OpenCode, Claude Code, Codex) and installs their plugins automatically. It also re-checks once a day, so an agent you install later gets picked up without needing to reload VS Code.
 
-- **OpenCode** — [opencode-plugin](./opencode-plugin/README.md), installed at `~/.config/opencode/plugin/tracybot-oc.js` (global) or `.opencode/plugin/tracybot-oc.js` (per project)
+- **OpenCode** — [opencode-plugin](./opencode-plugin/README.md), installed at `~/.config/opencode/plugin/tracybot-oc.js`
 - **Claude Code** — [claude-code-plugin](./claude-code-plugin/README.md), installed via hooks in `~/.claude/settings.json`
 - **Codex CLI** — [codex-plugin](./codex-plugin/README.md), installed via hooks in `~/.codex/hooks.json`
 
-You can install more than one if you use multiple agents — Tracybot records which one produced each Tasklet.
+Using more than one agent works fine — Tracybot records which one produced each Tasklet.
 
 ### 4. Start Using AI Blame
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -169,6 +169,13 @@ function getDisplayLineMapForDocument(document: vscode.TextDocument): Map<number
 // Status bar item that opens the blame panel when clicked
 let statusBarItem: vscode.StatusBarItem;
 
+// Agent detection (checkOpencode/checkHookBasedAgents) only runs on
+// activation or opening a new repo, so an agent installed mid-session (VS
+// Code windows often stay open for days) wouldn't be picked up until the
+// next reload. This re-runs the same idempotent checks once a day for
+// windows that stay open that long, without polling any more often than that.
+const AGENT_RECHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
 // Activate function
 export async function activate(context: vscode.ExtensionContext) {
   // git extension is a hard requirement for some functions
@@ -190,6 +197,12 @@ export async function activate(context: vscode.ExtensionContext) {
   };
 
   runInitialChecks();
+
+  const agentRecheckTimer = setInterval(() => {
+    checkOpencode(context);
+    checkHookBasedAgents(context);
+  }, AGENT_RECHECK_INTERVAL_MS);
+  context.subscriptions.push({ dispose: () => clearInterval(agentRecheckTimer) });
 
   // Status bar button — always visible, click opens the blame panel
   statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -5,6 +5,7 @@ import { History, TaskletUI, LineMap, Change } from './history/types';
 import { getBlameViewHtml } from './blameView';
 import { getRepoPath, mergeRemoteNotes } from './utils';
 import { checkOpencode } from './pluginCheck';
+import { checkHookBasedAgents } from './hookAgentPluginCheck';
 import { checkTracyInit } from './tracyInitCheck';
 import { checkResearchModeConsent } from './research/researchModeCheck';
 import { getConsentTier, getParticipantContext, isResearchModeEnabled } from './research/consent';
@@ -184,6 +185,7 @@ export async function activate(context: vscode.ExtensionContext) {
   const runInitialChecks = () => {
     checkTracyInit(context);
     checkOpencode(context);
+    checkHookBasedAgents(context);
     checkResearchModeConsent(context);
   };
 

--- a/vscode-extension/src/hookAgentPluginCheck.ts
+++ b/vscode-extension/src/hookAgentPluginCheck.ts
@@ -1,0 +1,193 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+import { homedir } from 'os';
+import { spawn, execSync } from 'child_process';
+
+// Claude Code and Codex both install via merging a hooks config JSON (unlike
+// OpenCode's single-file-drop plugin — see pluginCheck.ts), so this is one
+// generic, parameterized checker/installer for both rather than duplicated
+// per-agent logic.
+interface HookAgentConfig {
+  id: string;
+  displayName: string;
+  cliCommand: string;
+  hooksConfigPath: string;
+  hookScriptFilename: string;
+  installDir: string;
+  postToolUseMatcher: string;
+  failureCooldownKey: string;
+}
+
+// A failed install (e.g. Bun missing) shouldn't be retried on every single
+// activation — that would spam an error message the user can't act on
+// immediately. But it also can't be a permanent skip, or a user who fixes
+// the underlying problem (installs Bun) would never get auto-installed,
+// silently defeating the daily re-check in extension.ts. So failures get a
+// cooldown, not a permanent flag.
+const FAILURE_RETRY_COOLDOWN_MS = 24 * 60 * 60 * 1000;
+
+const AGENTS: HookAgentConfig[] = [
+  {
+    id: 'claude-code',
+    displayName: 'Claude Code',
+    cliCommand: 'claude',
+    hooksConfigPath: path.join(homedir(), '.claude', 'settings.json'),
+    hookScriptFilename: 'tracybot-cc-hook.js',
+    installDir: path.join(homedir(), '.claude', 'tracybot'),
+    postToolUseMatcher: 'Edit|Write|MultiEdit',
+    failureCooldownKey: 'tracybot.claudeCodeInstallFailureAt',
+  },
+  {
+    id: 'codex',
+    displayName: 'Codex CLI',
+    cliCommand: 'codex',
+    hooksConfigPath: path.join(homedir(), '.codex', 'hooks.json'),
+    hookScriptFilename: 'tracybot-codex-hook.js',
+    installDir: path.join(homedir(), '.codex', 'tracybot'),
+    postToolUseMatcher: 'apply_patch|Edit|Write',
+    failureCooldownKey: 'tracybot.codexInstallFailureAt',
+  },
+];
+
+function findCli(command: string): Promise<boolean> {
+  return new Promise(resolve => {
+    const proc = spawn(command, ['--version'], { stdio: 'ignore' });
+    proc.on('close', code => resolve(code === 0));
+    proc.on('error', () => resolve(false));
+  });
+}
+
+// Same rationale as the plugin packages' own deploy.js: a hook's execution
+// environment isn't guaranteed to have the same PATH as an interactive
+// shell, so an absolute path is resolved once here and baked into the hook
+// command rather than relying on a bare `bun` at hook-run time.
+function resolveBunPath(): string | undefined {
+  try {
+    return execSync('command -v bun', { encoding: 'utf8' }).trim();
+  } catch {
+    const fallback = path.join(homedir(), '.bun', 'bin', 'bun');
+    return fs.existsSync(fallback) ? fallback : undefined;
+  }
+}
+
+// undefined = file doesn't exist yet (fine, starts empty).
+// null = file exists but isn't valid JSON (caller must not overwrite it).
+function loadHooksConfig(configPath: string): any {
+  if (!fs.existsSync(configPath)) { return {}; }
+  try {
+    return JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function hasHookCommand(hookList: any[] | undefined, command: string): boolean {
+  return (hookList ?? []).some((entry: any) => (entry.hooks ?? []).some((h: any) => h.command === command));
+}
+
+// Checks both hooks installHooks() manages — checking only PostToolUse would
+// report "already configured" (and skip forever) even if Stop were somehow
+// missing, e.g. a user manually edited the config and removed just that one.
+function isAlreadyConfigured(agent: HookAgentConfig, scriptPath: string, bunPath: string): boolean {
+  const config = loadHooksConfig(agent.hooksConfigPath);
+  if (!config?.hooks) { return false; }
+  return hasHookCommand(config.hooks.PostToolUse, `${bunPath} ${scriptPath} post-tool-use`)
+    && hasHookCommand(config.hooks.Stop, `${bunPath} ${scriptPath} stop`);
+}
+
+async function downloadHookScript(agent: HookAgentConfig): Promise<string> {
+  const destPath = path.join(agent.installDir, agent.hookScriptFilename);
+  fs.mkdirSync(agent.installDir, { recursive: true });
+
+  const url = `https://github.com/TracyTeam/tracybot/releases/latest/download/${agent.hookScriptFilename}`;
+  const response = await fetch(url);
+  if (!response.ok) { throw new Error(`Plugin download failed: (${response.status})`); }
+
+  fs.writeFileSync(destPath, Buffer.from(await response.arrayBuffer()));
+  return destPath;
+}
+
+// Merges into any existing hooks config rather than overwriting it — mirrors
+// each plugin's own scripts/deploy.js exactly, so a user who later runs that
+// script manually (e.g. for development) sees the same idempotent behavior.
+function installHooks(agent: HookAgentConfig, scriptPath: string, bunPath: string): void {
+  const config = loadHooksConfig(agent.hooksConfigPath);
+  if (config === null) {
+    throw new Error(`${agent.hooksConfigPath} exists but isn't valid JSON — fix or remove it, then try again.`);
+  }
+
+  config.hooks ??= {};
+
+  config.hooks.PostToolUse ??= [];
+  const postToolUseCommand = `${bunPath} ${scriptPath} post-tool-use`;
+  if (!hasHookCommand(config.hooks.PostToolUse, postToolUseCommand)) {
+    config.hooks.PostToolUse.push({
+      matcher: agent.postToolUseMatcher,
+      hooks: [{ type: 'command', command: postToolUseCommand }],
+    });
+  }
+
+  config.hooks.Stop ??= [];
+  const stopCommand = `${bunPath} ${scriptPath} stop`;
+  if (!hasHookCommand(config.hooks.Stop, stopCommand)) {
+    config.hooks.Stop.push({ hooks: [{ type: 'command', command: stopCommand }] });
+  }
+
+  fs.mkdirSync(path.dirname(agent.hooksConfigPath), { recursive: true });
+  fs.writeFileSync(agent.hooksConfigPath, JSON.stringify(config, null, 2) + '\n');
+}
+
+// No confirmation prompt — installing Tracybot is itself the user's opt-in to
+// AI change tracing (that's the extension's whole stated purpose), so asking
+// again per detected agent is redundant friction, not extra consent. This
+// only wires up local, on-device tracking (hidden git commits) — nothing
+// leaves the machine from this step alone; that's what Research Mode's own,
+// separately-gated consent flow is for. Still surfaces a non-blocking
+// notification after installing, so the user isn't left unaware of what
+// just happened, and an error notification if it fails — neither requires a
+// click to dismiss or to proceed.
+async function checkAgent(context: vscode.ExtensionContext, agent: HookAgentConfig): Promise<void> {
+  const lastFailureAt = context.globalState.get<number>(agent.failureCooldownKey);
+  if (lastFailureAt && Date.now() - lastFailureAt < FAILURE_RETRY_COOLDOWN_MS) { return; }
+
+  const scriptPath = path.join(agent.installDir, agent.hookScriptFilename);
+  const existingBunPath = resolveBunPath();
+  if (existingBunPath && fs.existsSync(scriptPath) && isAlreadyConfigured(agent, scriptPath, existingBunPath)) {
+    return;
+  }
+
+  try {
+    if (!existingBunPath) {
+      throw new Error('Bun is required to run this plugin. Install it from https://bun.sh — Tracybot will pick it up automatically.');
+    }
+
+    const installedScriptPath = await downloadHookScript(agent);
+    installHooks(agent, installedScriptPath, existingBunPath);
+
+    vscode.window.showInformationMessage(`Tracybot: ${agent.displayName} plugin installed.`);
+  } catch (error) {
+    await context.globalState.update(agent.failureCooldownKey, Date.now());
+    vscode.window.showErrorMessage(
+      `Failed to install Tracybot ${agent.displayName} plugin: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}
+
+// Exported so pluginCheck.ts's OpenCode-specific "no supported agent found"
+// fallback can check these two before showing that message — otherwise a
+// Claude Code- or Codex-only user (no OpenCode) would incorrectly be told
+// they have no supported agent at all.
+export async function detectAnyHookAgent(): Promise<boolean> {
+  const results = await Promise.all(AGENTS.map(agent => findCli(agent.cliCommand)));
+  return results.some(Boolean);
+}
+
+export async function checkHookBasedAgents(context: vscode.ExtensionContext): Promise<void> {
+  for (const agent of AGENTS) {
+    const available = await findCli(agent.cliCommand);
+    if (!available) { continue; }
+
+    await checkAgent(context, agent);
+  }
+}

--- a/vscode-extension/src/pluginCheck.ts
+++ b/vscode-extension/src/pluginCheck.ts
@@ -3,20 +3,17 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { homedir } from 'os';
 import { spawn } from 'child_process';
+import { detectAnyHookAgent } from './hookAgentPluginCheck';
 
 const PLUGIN_FILENAME = 'tracybot-oc.js';
 const PLUGIN_URL = 'https://github.com/TracyTeam/tracybot/releases/latest/download/tracybot-oc.js';
-const SKIP_CHECK_KEY = 'tracybot.skipPluginCheck';
 const SKIP_OPENCODE_MISSING_KEY = 'tracybot.skipOpencodeMissingCheck';
 
-const Actions = {
-  InstallGlobally: 'Install Globally',
-  InstallForProject: 'Install for Project',
-  Ignore: 'Ignore',
-  NeverShowAgain: 'Never Show Again',
-} as const;
-
-type Action = (typeof Actions)[keyof typeof Actions];
+// Same rationale as hookAgentPluginCheck.ts: a failed install gets a cooldown,
+// not a permanent skip, so a transient failure can't permanently defeat the
+// daily re-check in extension.ts.
+const INSTALL_FAILURE_COOLDOWN_KEY = 'tracybot.opencodeInstallFailureAt';
+const FAILURE_RETRY_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 
 function getGlobalPluginPath(): string {
   return path.join(homedir(), '.config', 'opencode', 'plugin', PLUGIN_FILENAME);
@@ -53,10 +50,17 @@ async function findOpencode(): Promise<boolean> {
 }
 
 export async function checkOpencode(context: vscode.ExtensionContext): Promise<void> {
-  if (context.globalState.get<boolean>(SKIP_CHECK_KEY)) { return; }
+  const lastFailureAt = context.globalState.get<number>(INSTALL_FAILURE_COOLDOWN_KEY);
+  if (lastFailureAt && Date.now() - lastFailureAt < FAILURE_RETRY_COOLDOWN_MS) { return; }
 
   const opencodeAvailable = await findOpencode();
   if (!opencodeAvailable) {
+    // Claude Code or Codex being installed is enough — this message (and its
+    // "requires a supported agent" wording) is only accurate when none of
+    // the three are present. Those two get their own install prompts from
+    // checkHookBasedAgents; this function only owns OpenCode's.
+    if (await detectAnyHookAgent()) { return; }
+
     if (context.globalState.get<boolean>(SKIP_OPENCODE_MISSING_KEY)) { return; }
 
     const action = await vscode.window.showInformationMessage(
@@ -78,38 +82,19 @@ export async function checkOpencode(context: vscode.ExtensionContext): Promise<v
   const projectPath = getProjectPluginPath();
   if (projectPath && fs.existsSync(projectPath)) { return; }
 
-  const buttons: Action[] = [Actions.InstallGlobally];
-  if (projectPath) { buttons.push(Actions.InstallForProject); }
-  buttons.push(Actions.Ignore, Actions.NeverShowAgain);
-
-  const action = await vscode.window.showInformationMessage(
-    'Tracybot OpenCode plugin is not installed. Would you like to install now?',
-    ...buttons
-  );
-
-  if (action === Actions.NeverShowAgain) {
-    await context.globalState.update(SKIP_CHECK_KEY, true);
-    return;
-  }
-
-  // skip and catch-all for sanity
-  if (action !== Actions.InstallGlobally && action !== Actions.InstallForProject) { return; }
+  // No confirmation prompt — same rationale as checkHookBasedAgents: installing
+  // Tracybot already signals consent to trace AI changes, so this just installs
+  // globally (matching the other two agents' user-level install location) and
+  // tells the user afterward, without blocking on a click.
+  const installPath = getGlobalPluginPath();
 
   try {
-    let installPath;
-    if (action === Actions.InstallGlobally) {
-      installPath = getGlobalPluginPath();
-    } else {
-      if (!projectPath) { throw new Error("Not in a workspace."); }
-
-      installPath = projectPath;
-    }
-
     await installPluginTo(path.dirname(installPath));
-    vscode.window.showInformationMessage(`Tracybot OpenCode plugin installed to ${installPath}.`);
+    vscode.window.showInformationMessage(`Tracybot: OpenCode plugin installed to ${installPath}.`);
   } catch (error) {
+    await context.globalState.update(INSTALL_FAILURE_COOLDOWN_KEY, Date.now());
     vscode.window.showErrorMessage(
-      `Failed to install plugin: ${error instanceof Error ? error.message : String(error)}`
+      `Failed to install Tracybot OpenCode plugin: ${error instanceof Error ? error.message : String(error)}`
     );
   }
 }

--- a/vscode-extension/src/research/buildResearchPayloads.test.ts
+++ b/vscode-extension/src/research/buildResearchPayloads.test.ts
@@ -274,6 +274,48 @@ describe("buildTaskletResearchPayloads", () => {
       assert.ok(!payloads[0].build_response.includes("const x"));
     });
 
+    test("redacts home-directory paths (e.g. from markdown file links) outside code fences", () => {
+      const messages: TaskletMessage[] = [
+        { stage: "plan", type: "prompt", model: "anthropic/claude-sonnet-4-6", message: "Plan this" },
+        { stage: "plan", type: "response", model: "anthropic/claude-sonnet-4-6", message: "ok" },
+        { stage: "build", type: "prompt", model: "anthropic/claude-sonnet-4-6", message: "Build it" },
+        {
+          stage: "build", type: "response", model: "anthropic/claude-sonnet-4-6",
+          message: "I edited [utils.ts](/Users/esme/projects/secret-client/src/utils.ts) and " +
+            "also touched ~/work/other-project/config.json. See /home/esme/notes.md too.",
+        },
+      ];
+      const history = makeHistory([{ path: "src/app.ts", tasklets: [makeTasklet({ messages })] }]);
+      const payloads = buildTaskletResearchPayloads(history, 2, PARTICIPANT, SUBMITTED_AT) as Tier2Payload[];
+
+      assert.ok(!payloads[0].build_response.includes("esme"), "username should not leak");
+      assert.ok(!payloads[0].build_response.includes("secret-client"), "local project name should not leak");
+      assert.ok(!payloads[0].build_response.includes("other-project"), "local project name should not leak");
+      assert.equal(
+        payloads[0].build_response,
+        "I edited [utils.ts](<path omitted>) and also touched <path omitted>. See <path omitted> too."
+      );
+    });
+
+    test("leaves unrelated URLs and in-repo relative paths untouched", () => {
+      const messages: TaskletMessage[] = [
+        { stage: "plan", type: "prompt", model: "anthropic/claude-sonnet-4-6", message: "Plan this" },
+        { stage: "plan", type: "response", model: "anthropic/claude-sonnet-4-6", message: "ok" },
+        { stage: "build", type: "prompt", model: "anthropic/claude-sonnet-4-6", message: "Build it" },
+        {
+          stage: "build", type: "response", model: "anthropic/claude-sonnet-4-6",
+          message: "See https://example.com/Users/docs for reference; edited src/utils.ts.",
+        },
+      ];
+      const history = makeHistory([{ path: "src/app.ts", tasklets: [makeTasklet({ messages })] }]);
+      const payloads = buildTaskletResearchPayloads(history, 2, PARTICIPANT, SUBMITTED_AT) as Tier2Payload[];
+
+      assert.equal(
+        payloads[0].build_response,
+        "See https://example.com/Users/docs for reference; edited src/utils.ts."
+      );
+    });
+
     test("extracts structured questions_answers independent of message text", () => {
       const history = makeHistory([
         {

--- a/vscode-extension/src/research/buildResearchPayloads.ts
+++ b/vscode-extension/src/research/buildResearchPayloads.ts
@@ -124,6 +124,30 @@ function redactFencedCode(text: string): string {
   return text.replace(/```[\s\S]*?```/g, "[code omitted]");
 }
 
+// Agents often reference files with markdown links or plain paths, e.g.
+// "I edited [utils.ts](/Users/esme/projects/secret-client/src/utils.ts)" —
+// an absolute path rooted in a home directory leaks the participant's
+// username and local project/directory names, neither of which
+// redactFencedCode catches since this text sits outside any code fence.
+// Scoped to home-directory-style paths (not every "/" in the text) so it
+// doesn't also mangle unrelated content like URLs or in-repo relative paths.
+const HOME_DIR_PATH_RE = /(?<![\w.:/\\])(?:\/Users\/|\/home\/|~\/|[A-Za-z]:\\Users\\)[^\s)\]`"']+/g;
+
+// Trailing sentence punctuation (". "/", "/etc.) is a valid path character as
+// far as the regex is concerned, so a match like "config.json." would
+// otherwise swallow the full stop ending the sentence. Strip it back off
+// and keep it outside the placeholder.
+function redactFilePaths(text: string): string {
+  return text.replace(HOME_DIR_PATH_RE, match => {
+    const path = match.replace(/[.,;:!?]+$/, "");
+    return "<path omitted>" + match.slice(path.length);
+  });
+}
+
+function redactSensitiveText(text: string): string {
+  return redactFilePaths(redactFencedCode(text));
+}
+
 function messagesByStage(messages: TaskletMessage[], stage: "plan" | "build", type: "prompt" | "response"): string[] {
   return messages.filter(m => m.stage === stage && m.type === type).map(m => m.message);
 }
@@ -184,11 +208,14 @@ export function buildTaskletResearchPayloads(
     }
 
     const tier2Fields = {
-      plan_prompts: messagesByStage(group.messages, "plan", "prompt").map(redactFencedCode),
-      plan_responses: messagesByStage(group.messages, "plan", "response").map(redactFencedCode),
-      build_prompt: redactFencedCode(messagesByStage(group.messages, "build", "prompt")[0] ?? ""),
-      build_response: redactFencedCode(messagesByStage(group.messages, "build", "response")[0] ?? ""),
-      questions_answers: group.questions.map(q => ({ question: q.question, answer: q.answer })),
+      plan_prompts: messagesByStage(group.messages, "plan", "prompt").map(redactSensitiveText),
+      plan_responses: messagesByStage(group.messages, "plan", "response").map(redactSensitiveText),
+      build_prompt: redactSensitiveText(messagesByStage(group.messages, "build", "prompt")[0] ?? ""),
+      build_response: redactSensitiveText(messagesByStage(group.messages, "build", "response")[0] ?? ""),
+      questions_answers: group.questions.map(q => ({
+        question: redactSensitiveText(q.question),
+        answer: q.answer.map(redactSensitiveText),
+      })),
     };
 
     if (consentTier === 2) {


### PR DESCRIPTION
## Summary

OpenCode already had automatic CLI detection + an install prompt (`pluginCheck.ts`). Claude Code and Codex had no equivalent — worse, a Claude Code/Codex-only user (no OpenCode) was incorrectly told "requires a supported agent" by OpenCode's own fallback message, since that check only ever looked for the `opencode` binary.

- `hookAgentPluginCheck.ts`: generic, parameterized checker/installer shared by Claude Code and Codex — their install shape (merge into a hooks config JSON) is identical, unlike OpenCode's single-file plugin drop.
- `pluginCheck.ts`: OpenCode's "no supported agent" fallback now checks whether Claude Code or Codex is present first, so it only fires when truly none of the three are installed.
- **No confirmation prompts.** Installing Tracybot is itself the opt-in to AI change tracing, so all three agents (OpenCode, Claude Code, Codex) now install automatically as soon as their CLI is detected — a non-blocking notification fires afterward instead of a click-to-confirm dialog.
- **Daily re-check.** Detection previously only ran on activation / opening a repo, so an agent installed while a window stayed open (common — these windows often stay open for days) wasn't picked up until the next reload. A daily interval now re-runs the same idempotent checks.
- **Install-failure cooldown, not a permanent skip.** A failed install (e.g. Bun missing) used to set a permanent flag that blocked all future retries — even after the user fixed the problem, even via the new daily re-check. Replaced with a 24h cooldown: still no error spam on every activation, but a fixed problem is retried on the next check.
- **Research Mode privacy fix.** Agents often reference files with markdown links or plain paths (e.g. `[utils.ts](/Users/esme/projects/secret-client/src/utils.ts)`), which leaked the participant's username and local project/directory names in Tier 2+ prompt/response text — `redactFencedCode` only stripped fenced code blocks, not prose. Added `redactFilePaths`, scoped to home-directory-style paths (`~/`, `/Users/`, `/home/`, `C:\Users\`) so it doesn't also mangle URLs or in-repo relative paths.
- **Config-drift fix.** `isAlreadyConfigured()` only checked the `PostToolUse` hook entry, so if a user manually edited `~/.claude/settings.json`/`~/.codex/hooks.json` and removed just the `Stop` hook, it was reported as "already configured" and never restored. Now checks both.

## Test plan

- [x] `npm run compile` / `npm run lint` clean
- [x] Unit tests passing (39, including new coverage for the failure-cooldown fix and the path-redaction fix)
- [x] End-to-end verified against this machine's real Claude Code/Codex CLI installs — real detection, real download from the GitHub release, real hook config written, confirmed idempotent on a second run
- [x] Isolated fake-`$HOME`/fake-vscode-module harness covering: no agents detected, auto-install with no confirmation, idempotent re-check, later-installed agent picked up (simulating the daily re-check), install failure → single error → cooldown → auto-retry succeeds once the problem is fixed, same behavior for OpenCode
- [ ] `npm test` (VS Code integration suite) hit a local sandbox environment issue unrelated to this change (`vscode-test` couldn't launch a downloaded Electron binary) — should run cleanly in CI; flagging in case it needs a second look there

