### PR TITLE
Make Research Mode consent per-repository instead of machine-wide

### DIFF
--- a/docs/research-mode.md
+++ b/docs/research-mode.md
@@ -4,11 +4,11 @@ Research Mode is an opt-in feature that lets a Tracybot user share their Tasklet
 
 ## Consent
 
-On first activation, the VS Code extension shows a one-time prompt:
+Consent is **per repository**, not machine-wide — agreeing to share one project's Tasklet history doesn't enroll every other repo opened afterward. The first time a repo is opened (and once per repo thereafter, until a decision is made), the VS Code extension shows a prompt:
 
-> Help improve Tracybot: share your Tasklet history for a study on AI-assisted coding behavior?
+> Help improve Tracybot: share this repository's Tasklet history for a study on AI-assisted coding behavior?
 
-Agreeing enables Research Mode at **Tier 1** (the most conservative tier) and generates a random, per-machine `participant_id` that is never derived from git identity (`user.name`/`user.email`). The tier can be raised at any time via `tracybot.researchMode.consentTier` in Settings, and Research Mode can be disabled at any time (status bar → "Disable Research Mode", or the setting directly).
+Agreeing shows a Tier picker (Tier 1, the most conservative, is the default if dismissed) and generates a random, per-machine `participant_id` that is never derived from git identity (`user.name`/`user.email`) — the participant identity is shared across repos even though the enable/tier decision isn't. The decision (`enabled` + tier, or `declined`) is stored in that repo's `.git/tracybot/research-consent.json` — inside `.git` so it's never itself tracked or pushed by that repo's own history — and can be changed anytime from the Research Mode status bar item ("Disable for This Repo").
 
 ### Consent tiers
 
@@ -57,11 +57,13 @@ A rebuild-and-submit attempt happens on extension activation, on opening a repos
 
 ## Configuration reference
 
-| Setting | Default | Purpose |
-|---|---|---|
-| `tracybot.researchMode.enabled` | `false` | Master opt-in switch |
-| `tracybot.researchMode.consentTier` | `1` | `1`, `2`, or `3` — see tiers above |
-| `tracybot.researchMode.repoUrl` | `""` | Optional — shared only if the participant fills this in, lets researchers later check if a repo is open source |
+Stored per-repo in `.git/tracybot/research-consent.json` (see `vscode-extension/src/research/repoConsent.ts`), not as VS Code Settings:
+
+| Field | Purpose |
+|---|---|
+| `decision` | `"enabled"` or `"declined"` — absent entirely means undecided (prompt shows next time the repo is opened) |
+| `consentTier` | `1`, `2`, or `3` — see tiers above; only present when `decision` is `"enabled"` |
+| `repoUrl` | Optional, not currently set through any UI — lets researchers later check if a repo is open source, if manually added to the file |
 
 ## Local development
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -57,37 +57,7 @@
         "mac": "cmd+shift+0",
         "when": "editorTextFocus"
       }
-    ],
-    "configuration": {
-      "title": "Tracybot Research Mode",
-      "properties": {
-        "tracybot.researchMode.enabled": {
-          "type": "boolean",
-          "default": false,
-          "description": "Share your Tasklet history for a study on AI-assisted coding behavior. You can disable this at any time."
-        },
-        "tracybot.researchMode.consentTier": {
-          "type": "number",
-          "enum": [
-            1,
-            2,
-            3
-          ],
-          "enumDescriptions": [
-            "Stats only (model, timestamps, line counts)",
-            "+ prompt/response text (fenced code redacted)",
-            "+ code diffs touched by each Tasklet"
-          ],
-          "default": 1,
-          "description": "How much detail to share, if Research Mode is enabled."
-        },
-        "tracybot.researchMode.repoUrl": {
-          "type": "string",
-          "default": "",
-          "description": "Optional: share this repo's URL so researchers can check later if it's open source. Leave blank to omit."
-        }
-      }
-    }
+    ]
   },
   "scripts": {
     "clean": "rm -rf out assets init.py tracking",

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -9,6 +9,7 @@ import { checkHookBasedAgents } from './hookAgentPluginCheck';
 import { checkTracyInit } from './tracyInitCheck';
 import { checkResearchModeConsent } from './research/researchModeCheck';
 import { getConsentTier, getParticipantContext, isResearchModeEnabled } from './research/consent';
+import { writeRepoConsent } from './research/repoConsent';
 import { clearPendingPayloads, getPendingPayloads, getTodaysSentCount, queueTaskletForSubmission } from './research/queue';
 import { buildTaskletResearchPayloads } from './research/buildResearchPayloads';
 import { submitPayloads } from './research/collectorRepo';
@@ -88,7 +89,7 @@ async function buildHistoryAndSet(ctx: vscode.ExtensionContext): Promise<void> {
       fileTaskletsMap = buildFileTaskletsMap(history);
 
       await ctx.workspaceState.update('tracybot.buildHistoryCache', getSerializedCache());
-      await processNewTaskletsForResearch(ctx, result);
+      await processNewTaskletsForResearch(ctx, result, repoPath);
     } finally {
       buildHistoryLock = null;
     }
@@ -97,11 +98,13 @@ async function buildHistoryAndSet(ctx: vscode.ExtensionContext): Promise<void> {
   await buildHistoryLock;
 }
 
-// Status bar item showing today's Research Mode digest — only visible when enabled
+// Status bar item showing today's Research Mode digest — only visible when
+// the currently open repo has enabled it (consent is per-repo, see repoConsent.ts)
 let researchStatusBarItem: vscode.StatusBarItem;
 
-function updateResearchStatusBar(ctx: vscode.ExtensionContext): void {
-  if (!isResearchModeEnabled()) {
+async function updateResearchStatusBar(ctx: vscode.ExtensionContext): Promise<void> {
+  const repoPath = await getRepoPath();
+  if (!repoPath || !isResearchModeEnabled(repoPath)) {
     researchStatusBarItem.hide();
     return;
   }
@@ -119,18 +122,18 @@ function updateResearchStatusBar(ctx: vscode.ExtensionContext): void {
 // attempt to push everything pending to the collector repo — failures (no
 // network, no token configured yet, push rejected) just leave the queue as-is
 // for the next history rebuild to retry, so this is safe to call often.
-async function processNewTaskletsForResearch(ctx: vscode.ExtensionContext, h: History): Promise<void> {
-  if (!isResearchModeEnabled()) { return; }
+async function processNewTaskletsForResearch(ctx: vscode.ExtensionContext, h: History, repoPath: string): Promise<void> {
+  if (!isResearchModeEnabled(repoPath)) { return; }
 
-  const participant = getParticipantContext(ctx);
-  const payloads = buildTaskletResearchPayloads(h, getConsentTier(), participant);
+  const participant = getParticipantContext(ctx, repoPath);
+  const payloads = buildTaskletResearchPayloads(h, getConsentTier(repoPath), participant);
 
   for (const payload of payloads) {
     await queueTaskletForSubmission(ctx.globalState, payload);
   }
 
   await trySubmitPendingPayloads(ctx);
-  updateResearchStatusBar(ctx);
+  await updateResearchStatusBar(ctx);
 }
 
 async function trySubmitPendingPayloads(ctx: vscode.ExtensionContext): Promise<void> {
@@ -216,7 +219,7 @@ export async function activate(context: vscode.ExtensionContext) {
   researchStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 99);
   researchStatusBarItem.command = 'tracybot-extension.reviewResearchDigest';
   context.subscriptions.push(researchStatusBarItem);
-  updateResearchStatusBar(context);
+  await updateResearchStatusBar(context);
 
   context.subscriptions.push(
     vscode.commands.registerCommand('tracybot-extension.reviewResearchDigest', async () => {
@@ -227,7 +230,7 @@ export async function activate(context: vscode.ExtensionContext) {
         `Tracybot Research Mode: sent ${count} tasklet${count === 1 ? '' : 's'} today. ` +
         `${pending.length} total pending.`,
         'View Pending Data',
-        'Disable Research Mode'
+        'Disable for This Repo'
       );
 
       if (action === 'View Pending Data') {
@@ -236,16 +239,13 @@ export async function activate(context: vscode.ExtensionContext) {
           language: 'json',
         });
         await vscode.window.showTextDocument(doc);
-      } else if (action === 'Disable Research Mode') {
-        await vscode.workspace.getConfiguration('tracybot.researchMode')
-          .update('enabled', false, vscode.ConfigurationTarget.Global);
-        vscode.window.showInformationMessage('Tracybot Research Mode disabled.');
-        updateResearchStatusBar(context);
-      }
-    }),
-    vscode.workspace.onDidChangeConfiguration(e => {
-      if (e.affectsConfiguration('tracybot.researchMode.enabled')) {
-        updateResearchStatusBar(context);
+      } else if (action === 'Disable for This Repo') {
+        const repoPath = await getRepoPath();
+        if (repoPath) {
+          writeRepoConsent(repoPath, { decision: 'declined' });
+        }
+        vscode.window.showInformationMessage('Tracybot Research Mode disabled for this repository.');
+        await updateResearchStatusBar(context);
       }
     })
   );

--- a/vscode-extension/src/research/consent.ts
+++ b/vscode-extension/src/research/consent.ts
@@ -1,21 +1,14 @@
 import * as vscode from 'vscode';
 import { randomUUID } from 'crypto';
 import { ParticipantContext } from './types';
+import { getConsentTierForRepo, getRepoUrlForRepo, isResearchModeEnabledForRepo } from './repoConsent';
 
 const PARTICIPANT_ID_KEY = 'tracybot.researchMode.participantId';
 
-function getConfig() {
-  return vscode.workspace.getConfiguration('tracybot.researchMode');
-}
-
-export function isResearchModeEnabled(): boolean {
-  return getConfig().get<boolean>('enabled', false);
-}
-
-export function getConsentTier(): 1 | 2 | 3 {
-  const tier = getConfig().get<number>('consentTier', 1);
-  return tier === 2 || tier === 3 ? tier : 1;
-}
+// Enabled/tier/repoUrl are per-repository (see repoConsent.ts) — re-exported
+// here so callers only need one import for "am I collecting, and how much".
+export const isResearchModeEnabled = isResearchModeEnabledForRepo;
+export const getConsentTier = getConsentTierForRepo;
 
 // Generated locally on opt-in, stored per-machine (not per-workspace) since a
 // participant is a single person, not a single repo — and never derived from
@@ -31,12 +24,9 @@ export function getOrCreateParticipantId(context: vscode.ExtensionContext): stri
   return generated;
 }
 
-export function getParticipantContext(context: vscode.ExtensionContext): ParticipantContext {
-  const config = getConfig();
-  const repoUrl = config.get<string>('repoUrl', '').trim();
-
+export function getParticipantContext(context: vscode.ExtensionContext, repoPath: string): ParticipantContext {
   return {
     participantId: getOrCreateParticipantId(context),
-    repoUrl: repoUrl.length > 0 ? repoUrl : null,
+    repoUrl: getRepoUrlForRepo(repoPath),
   };
 }

--- a/vscode-extension/src/research/repoConsent.test.ts
+++ b/vscode-extension/src/research/repoConsent.test.ts
@@ -1,0 +1,74 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  readRepoConsent,
+  writeRepoConsent,
+  isResearchModeEnabledForRepo,
+  getConsentTierForRepo,
+  getRepoUrlForRepo,
+} from "./repoConsent";
+
+function makeRepo(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "tracybot-repo-consent-"));
+}
+
+describe("repoConsent", () => {
+  test("an undecided repo (no consent file) is not enabled and reads as undefined", () => {
+    const repo = makeRepo();
+    assert.equal(readRepoConsent(repo), undefined);
+    assert.equal(isResearchModeEnabledForRepo(repo), false);
+    assert.equal(getConsentTierForRepo(repo), 1);
+    assert.equal(getRepoUrlForRepo(repo), null);
+  });
+
+  test("writeRepoConsent persists an enabled decision under .git/tracybot/", () => {
+    const repo = makeRepo();
+    writeRepoConsent(repo, { decision: "enabled", consentTier: 2 });
+
+    assert.ok(fs.existsSync(path.join(repo, ".git", "tracybot", "research-consent.json")));
+    assert.equal(isResearchModeEnabledForRepo(repo), true);
+    assert.equal(getConsentTierForRepo(repo), 2);
+  });
+
+  test("a declined repo is not enabled but is still a terminal (non-undefined) decision", () => {
+    const repo = makeRepo();
+    writeRepoConsent(repo, { decision: "declined" });
+
+    assert.equal(isResearchModeEnabledForRepo(repo), false);
+    assert.notEqual(readRepoConsent(repo), undefined);
+    assert.equal(readRepoConsent(repo)?.decision, "declined");
+  });
+
+  test("consent for one repo does not leak into a sibling repo", () => {
+    const repoA = makeRepo();
+    const repoB = makeRepo();
+    writeRepoConsent(repoA, { decision: "enabled", consentTier: 3 });
+
+    assert.equal(isResearchModeEnabledForRepo(repoA), true);
+    assert.equal(isResearchModeEnabledForRepo(repoB), false);
+    assert.equal(readRepoConsent(repoB), undefined);
+  });
+
+  test("getRepoUrlForRepo returns the stored URL only when enabled and set", () => {
+    const repo = makeRepo();
+    writeRepoConsent(repo, { decision: "enabled", consentTier: 1, repoUrl: "https://example.com/repo" });
+    assert.equal(getRepoUrlForRepo(repo), "https://example.com/repo");
+
+    const declinedRepo = makeRepo();
+    writeRepoConsent(declinedRepo, { decision: "declined" });
+    assert.equal(getRepoUrlForRepo(declinedRepo), null);
+  });
+
+  test("a corrupted consent file is treated as undecided, not a crash", () => {
+    const repo = makeRepo();
+    const filePath = path.join(repo, ".git", "tracybot", "research-consent.json");
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, "{ not valid json");
+
+    assert.equal(readRepoConsent(repo), undefined);
+    assert.equal(isResearchModeEnabledForRepo(repo), false);
+  });
+});

--- a/vscode-extension/src/research/repoConsent.ts
+++ b/vscode-extension/src/research/repoConsent.ts
@@ -1,0 +1,48 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Research Mode consent is per-repository, not machine-wide — a participant
+// agreeing to share one project's Tasklet history shouldn't silently enroll
+// every other repo they ever open in VS Code afterward. Storing the decision
+// inside .git/tracybot/ (rather than a VS Code Setting) keeps it naturally
+// scoped to this one repo, and — since .git isn't tracked within itself —
+// never risks ending up committed and pushed to a shared remote the way a
+// workspace-level Setting in .vscode/settings.json could.
+export type RepoConsent =
+  | { decision: 'enabled'; consentTier: 1 | 2 | 3; repoUrl?: string }
+  | { decision: 'declined' };
+
+function consentFilePath(repoPath: string): string {
+  return path.join(repoPath, '.git', 'tracybot', 'research-consent.json');
+}
+
+export function readRepoConsent(repoPath: string): RepoConsent | undefined {
+  const filePath = consentFilePath(repoPath);
+  if (!fs.existsSync(filePath)) { return undefined; }
+
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return undefined;
+  }
+}
+
+export function writeRepoConsent(repoPath: string, consent: RepoConsent): void {
+  const filePath = consentFilePath(repoPath);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(consent, null, 2) + '\n');
+}
+
+export function isResearchModeEnabledForRepo(repoPath: string): boolean {
+  return readRepoConsent(repoPath)?.decision === 'enabled';
+}
+
+export function getConsentTierForRepo(repoPath: string): 1 | 2 | 3 {
+  const consent = readRepoConsent(repoPath);
+  return consent?.decision === 'enabled' ? consent.consentTier : 1;
+}
+
+export function getRepoUrlForRepo(repoPath: string): string | null {
+  const consent = readRepoConsent(repoPath);
+  return (consent?.decision === 'enabled' && consent.repoUrl) || null;
+}

--- a/vscode-extension/src/research/researchModeCheck.ts
+++ b/vscode-extension/src/research/researchModeCheck.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
-import { getOrCreateParticipantId, isResearchModeEnabled } from './consent';
-
-const SKIP_PROMPT_KEY = 'tracybot.skipResearchModePrompt';
+import { getRepoPath } from '../utils';
+import { getOrCreateParticipantId } from './consent';
+import { readRepoConsent, writeRepoConsent } from './repoConsent';
 
 interface TierPickItem extends vscode.QuickPickItem {
   tier: 1 | 2 | 3;
@@ -31,22 +31,27 @@ const TIER_OPTIONS: TierPickItem[] = [
   },
 ];
 
+// Per-repository, not machine-wide (see repoConsent.ts) — agreeing to share
+// one project's Tasklet history shouldn't silently enroll every other repo
+// opened afterward. Each repo gets asked once: "declined" and "enabled" are
+// both terminal decisions for that repo; only a genuinely undecided repo
+// (no consent file yet) prompts again.
 export async function checkResearchModeConsent(context: vscode.ExtensionContext): Promise<void> {
-  if (isResearchModeEnabled()) { return; }
-  if (context.globalState.get<boolean>(SKIP_PROMPT_KEY)) { return; }
+  const repoPath = await getRepoPath();
+  if (!repoPath) { return; }
+  if (readRepoConsent(repoPath)) { return; }
 
   const action = await vscode.window.showInformationMessage(
-    'Help improve Tracybot: share your Tasklet history for a study on AI-assisted coding behavior? ' +
-    'You can disable this anytime in Settings.',
+    'Help improve Tracybot: share this repository\'s Tasklet history for a study on AI-assisted coding behavior?',
     'I agree to share my data',
     'Not now',
-    'Never Show Again'
+    'Never for this repo'
   );
 
   if (action === 'I agree to share my data') {
     const chosen = await vscode.window.showQuickPick(TIER_OPTIONS, {
       title: 'Tracybot Research Mode — choose how much to share',
-      placeHolder: 'You can change this anytime in Settings → Tracybot Research Mode',
+      placeHolder: 'You can change or disable this anytime from the Research Mode status bar item',
       ignoreFocusOut: true,
     });
 
@@ -54,16 +59,15 @@ export async function checkResearchModeConsent(context: vscode.ExtensionContext)
     // conservative tier rather than leaving some other prior value in place.
     const tier = chosen?.tier ?? 1;
 
-    const config = vscode.workspace.getConfiguration('tracybot.researchMode');
-    await config.update('enabled', true, vscode.ConfigurationTarget.Global);
-    await config.update('consentTier', tier, vscode.ConfigurationTarget.Global);
+    writeRepoConsent(repoPath, { decision: 'enabled', consentTier: tier });
     getOrCreateParticipantId(context);
 
     vscode.window.showInformationMessage(
-      `Research Mode enabled at Tier ${tier}. Change this anytime in Settings → Tracybot Research Mode.`
+      `Research Mode enabled at Tier ${tier} for this repository. Change or disable it anytime from the Research Mode status bar item.`
     );
-  } else if (action === 'Never Show Again') {
-    await context.globalState.update(SKIP_PROMPT_KEY, true);
+  } else if (action === 'Never for this repo') {
+    writeRepoConsent(repoPath, { decision: 'declined' });
   }
-  // 'Not now' or dismissed: do nothing — stays unchecked, asked again next activation
+  // 'Not now' or dismissed: writes nothing — this repo stays undecided,
+  // asked again next time it's opened/activated.
 }


### PR DESCRIPTION
## Summary

Research Mode consent was stored via `ConfigurationTarget.Global`, so agreeing once in any one project silently enabled data collection for every other repo opened afterward on that machine — including repos unrelated to the study. A participant agreeing to share "this project's" Tasklet history reasonably wouldn't expect that to cover every other repo they touch.

- Adds `repoConsent.ts`: the enabled/tier/repoUrl decision is now stored in `<repo>/.git/tracybot/research-consent.json` — scoped naturally to that one repo, and never at risk of being committed/pushed itself since `.git` isn't tracked within its own repo (unlike a workspace-level VS Code Setting in `.vscode/settings.json`, which would be).
- `checkResearchModeConsent` now prompts per-repo; "declined" and "enabled" are both terminal decisions for that repo, so only a genuinely undecided repo prompts again.
- `isResearchModeEnabled`/`getConsentTier`/`getParticipantContext` now take a `repoPath` instead of reading a global VS Code Setting.
- The "Disable Research Mode" status bar action now disables for the current repo only ("Disable for This Repo").
- Removes the now-disconnected `tracybot.researchMode.*` entries from `package.json`'s Settings contribution — they no longer reflect real per-repo behavior, so leaving them would let a user flip a toggle in Settings that silently does nothing.
- Participant ID stays machine-wide (a participant is one person, not one repo), unchanged.

**Migration note:** anyone who already enabled Research Mode globally under the old scheme will be re-asked per-repo, since the new code doesn't read that old global Setting at all. This is an intentional one-time consequence of the fix, not a bug.

## Test plan

- [x] `npm run compile` / `npm run lint` clean
- [x] Unit tests passing (45, including 6 new tests in `repoConsent.test.ts`: undecided-repo defaults, enabled/declined persistence, no cross-repo leakage, `repoUrl` only surfacing when enabled, corrupted-file fails safe)
- [x] Isolated fake-repo/fake-vscode-module harness covering `checkResearchModeConsent`'s full interactive flow: undecided repo prompts, "Not now"/dismissed persists nothing and re-prompts next time, "I agree" + tier pick persists and never re-prompts, "Never for this repo" persists and never re-prompts, and a sibling repo's decision never leaks into a different repo
