### PR TITLE
Auto-initialize Tracybot in a repo without a confirmation prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Available on the [VS Code Marketplace](https://marketplace.visualstudio.com/item
 
 ### 1. Install the VS Code Extension
 
-This is the entry point to Tracybot. The extension can open AI Blame, prompt to initialize Tracybot in the current repository, and automatically installs plugins for any supported agent it detects on your machine.
+This is the entry point to Tracybot. The extension can open AI Blame, automatically initializes Tracybot in the current repository, and automatically installs plugins for any supported agent it detects on your machine.
 
 You can install the extension directly within VS Code:
 1. Open VS Code and go to the **Extensions** view (`Ctrl+Shift+X` or `Cmd+Shift+X`).
@@ -53,7 +53,7 @@ Alternatively, visit the [Tracybot VS Code Marketplace page](https://marketplace
 
 When the extension activates, it adds an `AI Blame` status bar item on the right side of VS Code.
 
-If Tracybot has not been initialized in the open repository yet, the extension offers to run initialization for you.
+If Tracybot has not been initialized in the open repository yet, the extension initializes it automatically.
 
 If you prefer to initialize from the terminal instead, run:
 

--- a/opencode-plugin/README.md
+++ b/opencode-plugin/README.md
@@ -6,7 +6,7 @@ An OpenCode plugin that records snapshots of your codebase after each AI interac
 
 The plugin intercepts AI responses and invokes the Tracy tracking system to create hidden Git commits that preserve the state of your code before and after each agent interaction. 
 
-If you are using Tracybot normally, install the [VS Code extension](../vscode-extension/README.md) first. It can prompt to install this plugin globally or for the current project. Manual installation methods are also provided below.
+If you are using Tracybot normally, install the [VS Code extension](../vscode-extension/README.md) first — it detects OpenCode and installs this plugin globally automatically. Manual installation methods are also provided below.
 
 ## Features
 

--- a/vscode-extension/DEVELOPMENT.md
+++ b/vscode-extension/DEVELOPMENT.md
@@ -1,0 +1,53 @@
+# Developing the Tracybot VS Code Extension
+
+This covers building, packaging, and debugging the extension from source. For what the extension does and how to install it, see [README.md](./README.md).
+
+## Install Dependencies
+
+```bash
+npm install
+```
+
+## Build the Extension
+
+```bash
+npm run compile
+```
+
+## Package the Extension (build VSCE package)
+
+```bash
+npm run package
+```
+
+## Deploy the Extension (build and install VSCE package)
+
+```bash
+npm run deploy
+```
+
+## Launch in Debug Mode
+
+Open `src/extension.ts` in VS Code and press `F5` to launch the extension debugger.
+
+## Install a Packaged VSIX Manually
+
+A VSIX package can be installed from the CLI:
+```bash
+code --install-extension vscode-extension.vsix
+```
+
+Build outputs are stored in `./out/`.
+
+Latest released `vscode-extension.vsix` can be downloaded from the [latest release](https://github.com/TracyTeam/tracybot/releases/latest).
+
+## Tests
+
+```bash
+npm run test:unit   # node:test suite under src/research/**/*.test.ts
+npm run lint
+```
+
+## Data Model
+
+A Tasklet's Zod schema is defined in `src/history/types.ts`.

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -11,6 +11,8 @@ The extension queries the Git repository to reconstruct the history of AI intera
 2. Extracting metadata from commit objects
 3. Building a timeline that maps code changes to AI interactions
 
+It also handles setup automatically: initializing Tracybot in a newly opened repository, and installing the plugin for whichever supported agent (OpenCode, Claude Code, Codex) is detected on your machine. No setup steps are required beyond installing the extension itself.
+
 ## Installation
 
 Installing the extension is the recommended way to get started with Tracybot.
@@ -44,9 +46,7 @@ irm https://raw.githubusercontent.com/TracyTeam/tracybot/main/vscode-extension/i
 ## Usage
 
 1. Open a Git repository in VS Code.
-2. If Tracybot has not been initialized in that repository yet, the extension initializes it automatically.
-3. Whichever supported agent's CLI is detected (OpenCode, Claude Code, Codex), the extension installs its plugin automatically — no confirmation needed. Tracybot records which agent produced each Tasklet.
-4. Click the `AI Blame` status bar item, or run `Tracybot: Open AI Blame window` from the command palette.
+2. Click the `AI Blame` status bar item, or run `Tracybot: Open AI Blame window` from the command palette.
 
 ## Requirements
 
@@ -63,55 +63,17 @@ Displays the history of AI-generated code changes in a dedicated editor tab. The
 - **Tasklet details**: Click on any highlighted line to see the originating tasklet, including which agent (OpenCode, Claude Code, or Codex) produced it
   - For OpenCode, a tasklet consists of 0 or more plan prompts followed by a build prompt
   - Claude Code and Codex have no separate planning stage, so their tasklets are a single prompt/response turn
-  - A tasklet Zod schema is available under `src/history/types.ts`
 - **File history**: View all tasklets that modified the current version of the file
 
 ## Research Mode
 
-An optional, opt-in feature to share your Tasklet history for a research study on AI-assisted coding behavior. Off by default, and can be disabled at any time from Settings. See [docs/research-mode.md](https://github.com/TracyTeam/tracybot/blob/main/docs/research-mode.md) in the main repository for what's collected and how consent works.
+An optional, opt-in feature to share your Tasklet history for a research study on AI-assisted coding behavior. Off by default, decided per-repository, and can be disabled at any time from the Research Mode status bar item. See [docs/research-mode.md](https://github.com/TracyTeam/tracybot/blob/main/docs/research-mode.md) in the main repository for what's collected and how consent works.
 
 ## Keybindings
 
 - `Cmd+Shift+0` (Mac) / `Ctrl+Shift+0` (Windows/Linux) - Open AI Blame window
 
-## Getting Started for Developers
+## Contributing
 
-### Install Dependencies
-
-```bash
-npm install
-```
-
-### Build the Extension
-
-```bash
-npm run compile
-```
-
-### Package the Extension (build VSCE package)
-
-```bash
-npm run package
-```
-
-### Deploy the Extension (build and install VSCE package)
-
-```bash
-npm run deploy
-```
-
-### Launch in Debug Mode
-
-Open `src/extension.ts` in VS Code and press `F5` to launch the extension debugger.
-
-### Install a Packaged VSIX Manually
-
-A VSIX package can be installed from the CLI:
-```bash
-code --install-extension vscode-extension.vsix
-```
-
-Build outputs are stored in `./out/`.
-
-Latest released `vscode-extension.vsix` can be downloaded from the [latest release](https://github.com/TracyTeam/tracybot/releases/latest).
+Building or debugging the extension from source? See [DEVELOPMENT.md](https://github.com/TracyTeam/tracybot/blob/main/vscode-extension/DEVELOPMENT.md).
 

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -44,8 +44,8 @@ irm https://raw.githubusercontent.com/TracyTeam/tracybot/main/vscode-extension/i
 ## Usage
 
 1. Open a Git repository in VS Code.
-2. If Tracybot has not been initialized in that repository yet, the extension offers to run initialization for you.
-3. If the OpenCode plugin is missing, the extension offers to install it globally or for the current workspace. Using Claude Code or Codex CLI instead? Install [claude-code-plugin](https://github.com/TracyTeam/tracybot/tree/main/claude-code-plugin) or [codex-plugin](https://github.com/TracyTeam/tracybot/tree/main/codex-plugin) — Tracybot records which agent produced each Tasklet either way.
+2. If Tracybot has not been initialized in that repository yet, the extension initializes it automatically.
+3. Whichever supported agent's CLI is detected (OpenCode, Claude Code, Codex), the extension installs its plugin automatically — no confirmation needed. Tracybot records which agent produced each Tasklet.
 4. Click the `AI Blame` status bar item, or run `Tracybot: Open AI Blame window` from the command palette.
 
 ## Requirements

--- a/vscode-extension/src/tracyInitCheck.ts
+++ b/vscode-extension/src/tracyInitCheck.ts
@@ -4,7 +4,11 @@ import * as path from 'path';
 import { spawn } from 'child_process';
 import { getRepoPath } from './utils';
 
-const SKIP_INIT_KEY = 'tracybot.skipTracyInit';
+// A failed init (e.g. no Python) gets a cooldown, not a permanent skip — same
+// rationale as hookAgentPluginCheck.ts: a since-fixed problem (Python
+// installed later) should get picked up again, not stay silenced forever.
+const INIT_FAILURE_COOLDOWN_KEY = 'tracybot.tracyInitFailureAt';
+const FAILURE_RETRY_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 
 async function findPython(): Promise<string> {
   for (const cmd of ['python3', 'python']) {
@@ -22,8 +26,14 @@ async function findPython(): Promise<string> {
   throw new Error('Python is not installed or not available.');
 }
 
+// No confirmation prompt — same rationale as hookAgentPluginCheck.ts:
+// installing Tracybot is itself the user's opt-in to AI change tracing, so
+// auto-initializing a detected repository is redundant friction, not extra
+// consent. Still surfaces a non-blocking notification once it's done, and an
+// error notification if it fails — neither requires a click to proceed.
 export async function checkTracyInit(context: vscode.ExtensionContext): Promise<void> {
-  if (context.globalState.get<boolean>(SKIP_INIT_KEY)) { return; }
+  const lastFailureAt = context.globalState.get<number>(INIT_FAILURE_COOLDOWN_KEY);
+  if (lastFailureAt && Date.now() - lastFailureAt < FAILURE_RETRY_COOLDOWN_MS) { return; }
 
   const repoPath = await getRepoPath();
   if (!repoPath) { return; }
@@ -31,26 +41,13 @@ export async function checkTracyInit(context: vscode.ExtensionContext): Promise<
   const tracyConfig = path.join(repoPath, '.git', 'tracybot', 'config');
   if (fs.existsSync(tracyConfig)) { return; }
 
-  const action = await vscode.window.showInformationMessage(
-    'Tracy is not initialized in this repository. Would you like to initialize it now?',
-    'Initialize',
-    'Ignore',
-    'Never Show Again'
-  );
-
-  if (action === 'Never Show Again') {
-    await context.globalState.update(SKIP_INIT_KEY, true);
-    return;
-  }
-
-  if (action !== 'Initialize') { return; }
-
   let python: string;
   try {
     python = await findPython();
   } catch (err) {
+    await context.globalState.update(INIT_FAILURE_COOLDOWN_KEY, Date.now());
     vscode.window.showErrorMessage(
-      `Failed to initialize Tracy: ${err instanceof Error ? err.message : String(err)}`
+      `Failed to initialize Tracybot in this repository: ${err instanceof Error ? err.message : String(err)}`
     );
     return;
   }
@@ -66,10 +63,11 @@ export async function checkTracyInit(context: vscode.ExtensionContext): Promise<
       proc.on('error', reject);
     });
 
-    vscode.window.showInformationMessage('Tracy initialized successfully.');
+    vscode.window.showInformationMessage('Tracybot: repository initialized.');
   } catch (error) {
+    await context.globalState.update(INIT_FAILURE_COOLDOWN_KEY, Date.now());
     vscode.window.showErrorMessage(
-      `Failed to initialize Tracy: ${error instanceof Error ? error.message : String(error)}`
+      `Failed to initialize Tracybot in this repository: ${error instanceof Error ? error.message : String(error)}`
     );
   }
 }


### PR DESCRIPTION
## Summary

Same rationale as the agent-plugin auto-install (#134): installing Tracybot is itself the user's opt-in to AI change tracing, so asking again per-repo ("would you like to initialize it now?") is redundant friction.

- `checkTracyInit` now runs `init.py` automatically as soon as an un-initialized repo is detected, with a non-blocking notification afterward instead of a click-to-confirm dialog.
- A failed init (e.g. no Python installed) gets a 24h retry cooldown rather than a permanent skip flag, so a since-fixed problem is picked up again on the next check instead of staying silenced forever — same fix already applied to the agent-plugin installers in #134.
- Splits developer docs out of `vscode-extension/README.md` into a new `DEVELOPMENT.md`: README.md ships as the VS Code Marketplace "Details" page, so it should only describe what a user does, not internal build/package/debug commands. Also trims the Usage section down to the two things a user actually does (open a repo, click AI Blame) — init and agent-plugin install are automatic now and don't belong in numbered user steps.
- Fixes remaining stale wording found while auditing docs: Research Mode's "disable from Settings" (moved to a per-repo status bar action in #135), and `opencode-plugin/README.md`'s "can prompt to install this plugin globally or for the current project" (now a silent, global-only auto-install).

## Test plan

- [x] `npm run compile` / `npm run lint` clean
- [x] Isolated fake-repo/fake-vscode-module harness covering: auto-init with no confirmation, idempotent silent skip once initialized, single error (no repeat spam) when Python is missing, and auto-retry succeeding once Python is available and the cooldown has elapsed
