### PR TITLE
Fix cross-repo data corruption from trusting the hook's cwd at Stop time

### DIFF
--- a/claude-code-plugin/src/index.ts
+++ b/claude-code-plugin/src/index.ts
@@ -1,6 +1,6 @@
 import { markFileEdited, readPendingTurn, clearPendingTurn } from "./state"
 import { extractTurnContext } from "./transcript"
-import { getRepoRoot, resolveTracyPath, detectPythonCommand, runTracySnapshot } from "./tracy"
+import { getRepoRootForEditedFiles, resolveTracyPath, detectPythonCommand, runTracySnapshot } from "./tracy"
 import type { ClaudeTurn } from "./types"
 
 const EDIT_TOOLS = new Set(["Edit", "Write", "MultiEdit"])
@@ -38,7 +38,9 @@ async function handleStop(): Promise<void> {
     const pending = await readPendingTurn(input.session_id)
     if (!pending || pending.editedFiles.length === 0) return // nothing edited this turn — mirrors OpenCode's toolCount > 0 gate
 
-    const repoRoot = await getRepoRoot(input.cwd)
+    // Derived from the actual edited files, not input.cwd — see
+    // getRepoRootForEditedFiles for why the hook's own cwd can't be trusted.
+    const repoRoot = await getRepoRootForEditedFiles(pending.editedFiles)
     if (!repoRoot) return
 
     const tracyPath = await resolveTracyPath(repoRoot)

--- a/claude-code-plugin/src/tracy.test.ts
+++ b/claude-code-plugin/src/tracy.test.ts
@@ -1,0 +1,61 @@
+import { test, expect, afterEach } from "bun:test"
+import path from "path"
+import os from "os"
+import fs from "fs"
+import { getRepoRoot, getRepoRootForEditedFiles } from "./tracy"
+
+const $ = Bun.$
+
+const tmpDirs: string[] = []
+
+afterEach(() => {
+    for (const dir of tmpDirs.splice(0)) {
+        fs.rmSync(dir, { recursive: true, force: true })
+    }
+})
+
+async function makeRepo(): Promise<string> {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tracy-repo-test-"))
+    tmpDirs.push(dir)
+    await $`git init -q`.cwd(dir).quiet()
+    return dir
+}
+
+test("getRepoRootForEditedFiles resolves the repo containing the edited files, ignoring an unrelated cwd", async () => {
+    const repoA = await makeRepo()
+    const repoB = await makeRepo()
+
+    const editedFile = path.join(repoA, "src", "file.ts")
+    fs.mkdirSync(path.dirname(editedFile), { recursive: true })
+    fs.writeFileSync(editedFile, "// edited")
+
+    // This mirrors the real bug: a session's shell cwd (repoB) drifting away
+    // from where the actual edits happened (repoA) must not affect which
+    // repo gets snapshotted.
+    const resolvedFromCwd = await getRepoRoot(repoB)
+    const resolvedFromEditedFiles = await getRepoRootForEditedFiles([editedFile])
+
+    expect(resolvedFromCwd).toBe(fs.realpathSync(repoB))
+    expect(resolvedFromEditedFiles).toBe(fs.realpathSync(repoA))
+    expect(resolvedFromEditedFiles).not.toBe(resolvedFromCwd)
+})
+
+test("getRepoRootForEditedFiles falls back to a later file if an earlier one no longer resolves", async () => {
+    const repo = await makeRepo()
+    const missingFile = path.join(os.tmpdir(), "tracy-repo-test-does-not-exist", "gone.ts")
+    const realFile = path.join(repo, "real.ts")
+    fs.writeFileSync(realFile, "// real")
+
+    const resolved = await getRepoRootForEditedFiles([missingFile, realFile])
+    expect(resolved).toBe(fs.realpathSync(repo))
+})
+
+test("getRepoRootForEditedFiles returns undefined when no edited file resolves to a repo", async () => {
+    const outsideAnyRepo = fs.mkdtempSync(path.join(os.tmpdir(), "tracy-no-repo-test-"))
+    tmpDirs.push(outsideAnyRepo)
+    const file = path.join(outsideAnyRepo, "orphan.ts")
+    fs.writeFileSync(file, "// orphan")
+
+    const resolved = await getRepoRootForEditedFiles([file])
+    expect(resolved).toBeUndefined()
+})

--- a/claude-code-plugin/src/tracy.ts
+++ b/claude-code-plugin/src/tracy.ts
@@ -66,6 +66,21 @@ export async function getRepoRoot(cwd: string): Promise<string | undefined> {
     }
 }
 
+// The hook event's own `cwd` is not a reliable "which repo is this turn
+// about" signal — it reflects whatever the session's shell happens to be in
+// at Stop time, which drifts on an ordinary `cd` (e.g. running a diagnostic
+// command in a different repo) with no actual edit involved. The edited
+// files themselves are the only ground truth for that, so the repo root is
+// derived from them instead — tried in order in case an earlier one no
+// longer resolves (e.g. a since-deleted file).
+export async function getRepoRootForEditedFiles(editedFiles: string[]): Promise<string | undefined> {
+    for (const file of editedFiles) {
+        const repoRoot = await getRepoRoot(path.dirname(file))
+        if (repoRoot) return repoRoot
+    }
+    return undefined
+}
+
 // Same shape of call opencode-plugin makes — tracy.py itself doesn't care
 // which agent produced the description, only that it's a string.
 export async function runTracySnapshot(

--- a/codex-plugin/src/index.ts
+++ b/codex-plugin/src/index.ts
@@ -32,7 +32,10 @@ async function handlePostToolUse(): Promise<void> {
     const input = await readStdinJson<ToolEventInput>()
     if (!input.tool_name || !EDIT_TOOLS.has(input.tool_name)) return
 
-    await markEdited(input.session_id)
+    // Resolved now, at the moment of the actual edit, rather than at Stop —
+    // see PendingTurnState.repoRoot for why Stop's own cwd can't be trusted.
+    const repoRoot = await getRepoRoot(input.cwd)
+    await markEdited(input.session_id, repoRoot)
 }
 
 async function handleStop(): Promise<void> {
@@ -41,7 +44,7 @@ async function handleStop(): Promise<void> {
     const pending = await readPendingTurn(input.session_id)
     if (!pending?.edited) return // nothing edited this turn — mirrors OpenCode's toolCount > 0 gate
 
-    const repoRoot = await getRepoRoot(input.cwd)
+    const repoRoot = pending.repoRoot
     if (!repoRoot) return
 
     const tracyPath = await resolveTracyPath(repoRoot)

--- a/codex-plugin/src/state.test.ts
+++ b/codex-plugin/src/state.test.ts
@@ -1,0 +1,49 @@
+import { test, expect, afterEach } from "bun:test"
+import { markEdited, readPendingTurn, clearPendingTurn } from "./state"
+
+const sessionIds: string[] = []
+
+afterEach(async () => {
+    for (const id of sessionIds.splice(0)) {
+        await clearPendingTurn(id)
+    }
+})
+
+function sessionId(): string {
+    const id = `state-test-${Date.now()}-${Math.random()}`
+    sessionIds.push(id)
+    return id
+}
+
+test("markEdited persists the repoRoot resolved at edit time", async () => {
+    const id = sessionId()
+    await markEdited(id, "/repo/a")
+
+    const pending = await readPendingTurn(id)
+    expect(pending).toEqual({ edited: true, repoRoot: "/repo/a" })
+})
+
+test("a later markEdited call in the same turn does not need to match an earlier one, but the last write wins", async () => {
+    const id = sessionId()
+    await markEdited(id, "/repo/a")
+    await markEdited(id, "/repo/a") // realistic case: multiple edits, same repo, same turn
+
+    const pending = await readPendingTurn(id)
+    expect(pending?.repoRoot).toBe("/repo/a")
+})
+
+test("markEdited tolerates an unresolved repoRoot without throwing", async () => {
+    const id = sessionId()
+    await markEdited(id, undefined)
+
+    const pending = await readPendingTurn(id)
+    expect(pending).toEqual({ edited: true, repoRoot: undefined })
+})
+
+test("clearPendingTurn removes the state so a stale repoRoot can't leak into the next turn", async () => {
+    const id = sessionId()
+    await markEdited(id, "/repo/a")
+    await clearPendingTurn(id)
+
+    expect(await readPendingTurn(id)).toBeUndefined()
+})

--- a/codex-plugin/src/state.ts
+++ b/codex-plugin/src/state.ts
@@ -10,8 +10,8 @@ function statePath(sessionId: string): string {
     return path.join(os.tmpdir(), `tracybot-codex-turn-${sessionId}.json`)
 }
 
-export async function markEdited(sessionId: string): Promise<void> {
-    const state: PendingTurnState = { edited: true }
+export async function markEdited(sessionId: string, repoRoot: string | undefined): Promise<void> {
+    const state: PendingTurnState = { edited: true, repoRoot }
     await Bun.write(statePath(sessionId), JSON.stringify(state))
 }
 

--- a/codex-plugin/src/tracy.ts
+++ b/codex-plugin/src/tracy.ts
@@ -66,6 +66,21 @@ export async function getRepoRoot(cwd: string): Promise<string | undefined> {
     }
 }
 
+// The hook event's own `cwd` is not a reliable "which repo is this turn
+// about" signal — it reflects whatever the session's shell happens to be in
+// at Stop time, which drifts on an ordinary `cd` (e.g. running a diagnostic
+// command in a different repo) with no actual edit involved. The edited
+// files themselves are the only ground truth for that, so the repo root is
+// derived from them instead — tried in order in case an earlier one no
+// longer resolves (e.g. a since-deleted file).
+export async function getRepoRootForEditedFiles(editedFiles: string[]): Promise<string | undefined> {
+    for (const file of editedFiles) {
+        const repoRoot = await getRepoRoot(path.dirname(file))
+        if (repoRoot) return repoRoot
+    }
+    return undefined
+}
+
 // Same shape of call opencode-plugin/claude-code-plugin make — tracy.py
 // itself doesn't care which agent produced the description, only that it's
 // a string.

--- a/codex-plugin/src/types.ts
+++ b/codex-plugin/src/types.ts
@@ -18,6 +18,14 @@ export interface CodexTurn {
 // than parse an unconfirmed patch format, this only tracks *whether* an edit
 // happened this turn, which is all the gating logic (mirroring OpenCode's
 // toolCount > 0) actually needs.
+//
+// repoRoot is resolved from the hook's cwd at PostToolUse time (right when
+// the edit happens) and reused as-is at Stop, rather than re-resolving cwd
+// at Stop time — a session's shell cwd can drift after the edit (e.g. a
+// later, unrelated `cd` into a different repo to run some diagnostic
+// command), and Stop firing with that drifted cwd would snapshot the wrong
+// repo entirely.
 export interface PendingTurnState {
   edited: boolean
+  repoRoot?: string
 }

--- a/vscode-extension/src/utils.ts
+++ b/vscode-extension/src/utils.ts
@@ -501,15 +501,24 @@ export async function getRepoPath(): Promise<string | undefined> {
     return git.repositories[0].rootUri.fsPath;
   }
 
-  // If there are multiple repos, try to find the one containing the active file
+  // If there are multiple repos, try to find the one containing the active file.
+  // For a repo nested inside another repo (e.g. a project cloned into a
+  // subfolder of a parent repo), the active file's path is a prefix match for
+  // BOTH — picking the first match (in whatever order git.repositories
+  // happens to enumerate) can resolve to the outer, wrong repo instead of the
+  // inner one that actually contains the file. The most specific match (the
+  // longest matching rootUri) is always the correct, innermost repo.
   const activeEditor = vscode.window.activeTextEditor;
   if (activeEditor) {
-    const repo = git.repositories.find((r: { rootUri: vscode.Uri }) =>
+    const matchingRepos = git.repositories.filter((r: { rootUri: vscode.Uri }) =>
       activeEditor.document.uri.fsPath.startsWith(r.rootUri.fsPath)
     );
 
-    if (repo) {
-      return repo.rootUri.fsPath;
+    if (matchingRepos.length > 0) {
+      const mostSpecific = matchingRepos.reduce((a: { rootUri: vscode.Uri }, b: { rootUri: vscode.Uri }) =>
+        b.rootUri.fsPath.length > a.rootUri.fsPath.length ? b : a
+      );
+      return mostSpecific.rootUri.fsPath;
     }
   }
 


### PR DESCRIPTION
## Summary

Found via a real submitted Research Mode record: a Tasklet's `build_prompt`/`build_response` came from one Claude Code session (working in the `tracybot` repo), but its `diff_hunks` belonged to a completely different, unrelated Claude Code session's edits in a different repo (`web_engineering`).

**Root cause:** both `claude-code-plugin` and `codex-plugin` resolved `repoRoot` from the Stop hook's own `cwd` field, which reflects whatever the session's shell currently happens to be in — not which repo the turn's actual edits belong to. An ordinary diagnostic `cd` into a different repo (no edit involved) between the real edits and Stop firing is enough to make Stop snapshot the wrong repo, silently overwriting that other repo's own in-progress `tracy-local` chain with unrelated prompt/response text.

- **claude-code-plugin**: `repoRoot` is now derived from the actual edited file paths (already tracked per-file in `PendingTurnState`), trying each in order — the only real ground truth for "which repo did this turn touch," immune to cwd drift at any point.
- **codex-plugin**: `PendingTurnState` doesn't track individual file paths (`apply_patch` reports changes as unparsed patch/command text, not a clean path — a deliberate prior tradeoff, left alone here). Instead, `repoRoot` is now resolved from `cwd` at PostToolUse time (right when the edit happens) and pinned into pending state, so Stop reuses that instead of re-deriving from its own, possibly-drifted `cwd`.
- **OpenCode is unaffected** — its plugin resolves `repoRoot` once from the SDK's own `directory` at plugin init, tied to the long-lived session process rather than re-read per hook event.

Note: this means some already-submitted Research Mode records may contain this same cross-repo mismatch. Per team decision, all current collector data is test data slated for deletion regardless, so no separate cleanup is included in this PR.

## Test plan

- [x] `claude-code-plugin`: `bun test` (9 pass, including new `tracy.test.ts`: repo resolution from edited files ignores an unrelated `cwd`, falls back past a since-deleted file, returns `undefined` with no resolvable repo) and `bun run build` clean
- [x] `codex-plugin`: `bun test` (9 pass, including new `state.test.ts`: `repoRoot` persists across the turn, survives an unresolved value without throwing, clears with the rest of pending state) and `bun run build` clean


---

## Update: also fixes a related "wrong repo" bug

Rolled into this PR since it's the same class of issue — trusting an ambient signal instead of ground truth for "which repo does this belong to."

`getRepoPath()` picked the active editor's repo via `git.repositories.find()`, matching whichever repo's `rootUri` is a path prefix of the active file. For a repo nested inside another repo (e.g. a project cloned into a subfolder of a parent repo that's also its own git repo), the active file's path is a prefix match for **both** — `find()` returns whichever comes first in `git.repositories`' enumeration order, which can be the wrong (outer) repo instead of the inner one that actually contains the file.

Found via a real case: a nested repo's uncommitted AI edit was captured correctly (confirmed via its `refs/tracy-local` ref and a successfully submitted Research Mode payload), but AI Blame reported "No AI-generated lines found" for that file — because by the time AI Blame ran, `getRepoPath()` had resolved to the outer repo instead, which naturally has no tracy data at all.

Fixed by picking the most specific (longest matching `rootUri`) repo instead of the first match. Verified with an isolated fake-vscode-module harness: nested repo resolves correctly regardless of array order, a file genuinely in the outer repo still resolves to the outer repo, and unrelated sibling repos are unaffected.
