### PR TITLE
Fix agent-setup cooldown, add Install Bun button, Research Mode tier management, and a clearer AI Blame error

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -47,7 +47,7 @@
       },
       {
         "command": "tracybot-extension.reviewResearchDigest",
-        "title": "Tracybot: Review Research Mode Data"
+        "title": "Tracybot: Manage Research Mode"
       }
     ],
     "keybindings": [

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -68,7 +68,7 @@
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src",
     "test": "vscode-test",
-    "test:unit": "tsc -p ./ && node --test out/research/**/*.test.js",
+    "test:unit": "tsc -p ./ && node --test out/research/**/*.test.js out/*.test.js",
     "package": "vsce package -o out/tracybot-extension.vsix",
     "deploy": "npm run package && code --install-extension out/tracybot-extension.vsix"
   },

--- a/vscode-extension/src/bunInstall.test.ts
+++ b/vscode-extension/src/bunInstall.test.ts
@@ -1,0 +1,17 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { getBunInstallCommand } from "./bunInstall";
+
+describe("bunInstall", () => {
+  test("uses the PowerShell installer on Windows", () => {
+    assert.equal(getBunInstallCommand("win32"), 'powershell -c "irm bun.sh/install.ps1 | iex"');
+  });
+
+  test("uses the curl installer on macOS", () => {
+    assert.equal(getBunInstallCommand("darwin"), "curl -fsSL https://bun.sh/install | bash");
+  });
+
+  test("uses the curl installer on Linux", () => {
+    assert.equal(getBunInstallCommand("linux"), "curl -fsSL https://bun.sh/install | bash");
+  });
+});

--- a/vscode-extension/src/bunInstall.ts
+++ b/vscode-extension/src/bunInstall.ts
@@ -1,0 +1,10 @@
+// Bun's own official one-line installers — kept manual/click-driven rather
+// than silently auto-run: installing a new system-wide runtime and touching
+// the user's shell profile is a bigger, more sensitive action than anything
+// else this extension automates (all of which is scoped to files inside the
+// user's own repo or its .git folder).
+export function getBunInstallCommand(platform: NodeJS.Platform = process.platform): string {
+  return platform === 'win32'
+    ? 'powershell -c "irm bun.sh/install.ps1 | iex"'
+    : 'curl -fsSL https://bun.sh/install | bash';
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 
-import { buildHistory, hydrateCache, getSerializedCache, clearCache } from './history/buildHistory';
-import { History, TaskletUI, LineMap, Change } from './history/types';
+import { buildHistory, describeBuildHistoryFailure, hydrateCache, getSerializedCache, clearCache } from './history/buildHistory';
+import { BuildHistoryFailureReason, History, TaskletUI, LineMap, Change } from './history/types';
 import { getBlameViewHtml } from './blameView';
 import { getRepoPath, mergeRemoteNotes } from './utils';
 import { checkOpencode } from './pluginCheck';
@@ -17,6 +17,7 @@ import { submitPayloads } from './research/collectorRepo';
 // History data — populated asynchronously when the extension activates
 let history: History | undefined;
 let buildHistoryLock: Promise<void> | null = null;
+let lastBuildHistoryFailureReason: BuildHistoryFailureReason | undefined;
 
 // Maps a relative file path to a map of line number -> Tasklet
 // Built once after history loads; updated on each blameAI invocation
@@ -74,22 +75,24 @@ async function buildHistoryAndSet(ctx: vscode.ExtensionContext): Promise<void> {
       const result = await buildHistory(repoPath);
       console.log(`History build time: ${Date.now() - time}ms`);
 
-      if (!result) {
-        console.error('Failed to build history');
+      if (!result.ok) {
+        console.error('Failed to build history:', result.reason);
+        lastBuildHistoryFailureReason = result.reason;
         return;
       }
 
-      result.files.forEach(file =>
+      lastBuildHistoryFailureReason = undefined;
+      result.history.files.forEach(file =>
         file.tasklets.forEach(t => (t as TaskletUI).selected = false)
       );
 
-      history = result as unknown as { files: { path: string; tasklets: TaskletUI[] }[] } & History;
+      history = result.history as unknown as { files: { path: string; tasklets: TaskletUI[] }[] } & History;
       lineMap = buildLineMap(history);
       displayLineMap = new Map(lineMap);
       fileTaskletsMap = buildFileTaskletsMap(history);
 
       await ctx.workspaceState.update('tracybot.buildHistoryCache', getSerializedCache());
-      await processNewTaskletsForResearch(ctx, result, repoPath);
+      await processNewTaskletsForResearch(ctx, result.history, repoPath);
     } finally {
       buildHistoryLock = null;
     }
@@ -328,7 +331,7 @@ export async function activate(context: vscode.ExtensionContext) {
       );
 
       if (!history) {
-        vscode.window.showErrorMessage('AI Blame: Failed to build history.');
+        vscode.window.showErrorMessage(describeBuildHistoryFailure(lastBuildHistoryFailureReason ?? 'build-error'));
         return;
       }
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -7,9 +7,9 @@ import { getRepoPath, mergeRemoteNotes } from './utils';
 import { checkOpencode } from './pluginCheck';
 import { checkHookBasedAgents } from './hookAgentPluginCheck';
 import { checkTracyInit } from './tracyInitCheck';
-import { checkResearchModeConsent } from './research/researchModeCheck';
+import { checkResearchModeConsent, enableResearchModeForRepo, pickResearchModeTier } from './research/researchModeCheck';
 import { getConsentTier, getParticipantContext, isResearchModeEnabled } from './research/consent';
-import { writeRepoConsent } from './research/repoConsent';
+import { readRepoConsent, writeRepoConsent } from './research/repoConsent';
 import { clearPendingPayloads, getPendingPayloads, getTodaysSentCount, queueTaskletForSubmission } from './research/queue';
 import { buildTaskletResearchPayloads } from './research/buildResearchPayloads';
 import { submitPayloads } from './research/collectorRepo';
@@ -221,8 +221,39 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(researchStatusBarItem);
   await updateResearchStatusBar(context);
 
+  // Same command whether reached from the status bar (only visible once
+  // enabled) or the Command Palette (always available, no "when" clause) —
+  // it branches on the current repo's consent state so undecided/declined
+  // repos have a real entry point too, not just enabled ones.
   context.subscriptions.push(
     vscode.commands.registerCommand('tracybot-extension.reviewResearchDigest', async () => {
+      const repoPath = await getRepoPath();
+      if (!repoPath) {
+        vscode.window.showInformationMessage('Tracybot Research Mode: open a folder inside a git repository first.');
+        return;
+      }
+
+      const consent = readRepoConsent(repoPath);
+
+      if (!consent) {
+        await checkResearchModeConsent(context);
+        await updateResearchStatusBar(context);
+        return;
+      }
+
+      if (consent.decision === 'declined') {
+        const action = await vscode.window.showInformationMessage(
+          'Research Mode is currently declined for this repository.',
+          'Re-enable',
+          'Keep Declined'
+        );
+        if (action === 'Re-enable') {
+          await enableResearchModeForRepo(context, repoPath);
+          await updateResearchStatusBar(context);
+        }
+        return;
+      }
+
       const count = getTodaysSentCount(context.globalState);
       const pending = getPendingPayloads(context.globalState);
 
@@ -230,6 +261,7 @@ export async function activate(context: vscode.ExtensionContext) {
         `Tracybot Research Mode: sent ${count} tasklet${count === 1 ? '' : 's'} today. ` +
         `${pending.length} total pending.`,
         'View Pending Data',
+        'Change Tier',
         'Disable for This Repo'
       );
 
@@ -239,11 +271,16 @@ export async function activate(context: vscode.ExtensionContext) {
           language: 'json',
         });
         await vscode.window.showTextDocument(doc);
-      } else if (action === 'Disable for This Repo') {
-        const repoPath = await getRepoPath();
-        if (repoPath) {
-          writeRepoConsent(repoPath, { decision: 'declined' });
+      } else if (action === 'Change Tier') {
+        const tier = await pickResearchModeTier();
+        // Dismissed: leave the existing tier untouched — this is a change,
+        // not a fresh opt-in, so it shouldn't silently downgrade to Tier 1.
+        if (tier !== undefined) {
+          writeRepoConsent(repoPath, { ...consent, consentTier: tier });
+          vscode.window.showInformationMessage(`Research Mode tier changed to Tier ${tier} for this repository.`);
         }
+      } else if (action === 'Disable for This Repo') {
+        writeRepoConsent(repoPath, { decision: 'declined' });
         vscode.window.showInformationMessage('Tracybot Research Mode disabled for this repository.');
         await updateResearchStatusBar(context);
       }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -65,6 +65,16 @@ async function buildHistoryAndSet(ctx: vscode.ExtensionContext): Promise<void> {
 
   const repoPath = await getRepoPath();
   if (!repoPath) {
+    // getRepoPath() relies on VS Code's Git API and therefore returns
+    // undefined before buildHistory() can classify the failure itself. Keep
+    // the UI state in sync with that result so AI Blame reports the useful
+    // "no repository" message instead of falling back to build-error (or,
+    // worse, rendering attribution cached for a previously open repo).
+    lastBuildHistoryFailureReason = 'no-repo-path';
+    history = undefined;
+    lineMap = new Map();
+    displayLineMap = new Map();
+    fileTaskletsMap = new Map();
     return;
   }
 
@@ -78,6 +88,10 @@ async function buildHistoryAndSet(ctx: vscode.ExtensionContext): Promise<void> {
       if (!result.ok) {
         console.error('Failed to build history:', result.reason);
         lastBuildHistoryFailureReason = result.reason;
+        history = undefined;
+        lineMap = new Map();
+        displayLineMap = new Map();
+        fileTaskletsMap = new Map();
         return;
       }
 

--- a/vscode-extension/src/failureCooldown.test.ts
+++ b/vscode-extension/src/failureCooldown.test.ts
@@ -1,0 +1,58 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { CooldownStore, FAILURE_RETRY_COOLDOWN_MS, clearFailureCooldown, notifyFailureOnce } from "./failureCooldown";
+
+function makeStore(): CooldownStore & { data: Map<string, unknown> } {
+  const data = new Map<string, unknown>();
+  return {
+    data,
+    get: <T,>(key: string) => data.get(key) as T | undefined,
+    update: (key: string, value: unknown) => { data.set(key, value); },
+  };
+}
+
+describe("failureCooldown", () => {
+  test("notifyFailureOnce notifies on the first failure", async () => {
+    const store = makeStore();
+    let calls = 0;
+    await notifyFailureOnce(store, "k", () => { calls++; });
+    assert.equal(calls, 1);
+  });
+
+  test("notifyFailureOnce does not re-notify for a second failure within the cooldown window", async () => {
+    const store = makeStore();
+    let calls = 0;
+    await notifyFailureOnce(store, "k", () => { calls++; });
+    await notifyFailureOnce(store, "k", () => { calls++; });
+    assert.equal(calls, 1);
+  });
+
+  test("notifyFailureOnce notifies again once the cooldown window has elapsed", async () => {
+    const store = makeStore();
+    let calls = 0;
+    store.data.set("k", Date.now() - (FAILURE_RETRY_COOLDOWN_MS + 1000));
+    await notifyFailureOnce(store, "k", () => { calls++; });
+    assert.equal(calls, 1);
+  });
+
+  test("clearFailureCooldown immediately un-suppresses the next failure", async () => {
+    const store = makeStore();
+    let calls = 0;
+    await notifyFailureOnce(store, "k", () => { calls++; });
+    await clearFailureCooldown(store, "k");
+    await notifyFailureOnce(store, "k", () => { calls++; });
+    assert.equal(calls, 2);
+  });
+
+  test("cooldowns for different keys are independent", async () => {
+    const store = makeStore();
+    let callsA = 0;
+    let callsB = 0;
+    await notifyFailureOnce(store, "a", () => { callsA++; });
+    await notifyFailureOnce(store, "b", () => { callsB++; });
+    await notifyFailureOnce(store, "a", () => { callsA++; });
+    await notifyFailureOnce(store, "b", () => { callsB++; });
+    assert.equal(callsA, 1);
+    assert.equal(callsB, 1);
+  });
+});

--- a/vscode-extension/src/failureCooldown.ts
+++ b/vscode-extension/src/failureCooldown.ts
@@ -1,0 +1,40 @@
+// Subset of vscode.Memento's shape — same convention as research/queue.ts's
+// KeyValueStore — lets this module be unit-tested with a plain in-memory
+// fake, no real 'vscode' module needed at runtime or in tests.
+export interface CooldownStore {
+  get<T>(key: string): T | undefined;
+  update(key: string, value: unknown): Thenable<void> | void;
+}
+
+// A failed attempt (missing dependency, flaky network, ...) shouldn't be
+// reshown on every single activation — that would spam a notification the
+// user can't act on immediately. But the cooldown must NEVER gate the check
+// or the attempt itself, only the repeat *notification* — otherwise a user
+// who fixes the problem (installs Bun, network comes back) doesn't get
+// picked up again for up to 24h, even across reloads, since this is backed
+// by globalState.
+export const FAILURE_RETRY_COOLDOWN_MS = 24 * 60 * 60 * 1000;
+
+// Clears any stored cooldown for `key`. Call this on every success path
+// (including "already fine, nothing to do") so a later, unrelated failure
+// doesn't inherit a stale suppression window from an old, now-resolved one.
+export async function clearFailureCooldown(store: CooldownStore, key: string): Promise<void> {
+  await store.update(key, undefined);
+}
+
+// Runs `notify` only if the same failure hasn't already been shown to the
+// user within the cooldown window, then records "shown" now. Callers must
+// have already re-run their full check/attempt before calling this — this
+// function only throttles the notification, nothing else.
+export async function notifyFailureOnce(
+  store: CooldownStore,
+  key: string,
+  notify: () => Promise<void> | void
+): Promise<void> {
+  const lastShownAt = store.get<number>(key);
+  if (lastShownAt && Date.now() - lastShownAt < FAILURE_RETRY_COOLDOWN_MS) {
+    return;
+  }
+  await store.update(key, Date.now());
+  await notify();
+}

--- a/vscode-extension/src/history/buildHistory.ts
+++ b/vscode-extension/src/history/buildHistory.ts
@@ -1,4 +1,4 @@
-import { Change, CommitInfo, DiffHunk, History, TaskletMessage, TaskletQuestion } from "./types";
+import { BuildHistoryFailureReason, BuildHistoryResult, Change, CommitInfo, DiffHunk, History, TaskletMessage, TaskletQuestion } from "./types";
 import {
   getActiveTracyId,
   getCommitTree,
@@ -746,30 +746,42 @@ function deduplicateAILines(changes: Change[]): Change[] {
   return result;
 }
 
-export async function buildHistory(repoPath: string | undefined): Promise<History | null> {
+export async function buildHistory(repoPath: string | undefined): Promise<BuildHistoryResult> {
   if (!repoPath) {
-    return null;
+    return { ok: false, reason: 'no-repo-path' };
   }
 
   try {
     await runGit(repoPath, ["rev-parse", "--is-inside-work-tree"]);
   } catch (error) {
     console.error("Not a valid git repository:", error);
-
-    return null;
+    return { ok: false, reason: 'not-a-git-repo' };
   }
 
   try {
-    const mainCommits = await getMainCommits(repoPath);
+    let mainCommits: CommitInfo[];
+    try {
+      mainCommits = await getMainCommits(repoPath);
+    } catch (error) {
+      // `git log` itself fails (exit 128, "does not have any commits yet")
+      // on a freshly-initialized repo — mainCommits.length === 0 below never
+      // actually fires for that case, getMainCommits throws first. Any other
+      // reason `git log` could fail here (the is-inside-work-tree check
+      // above already passed) is rare enough that folding it into
+      // "no commits" is an acceptable, much simpler trade-off than parsing
+      // git's stderr text.
+      console.error("Failed to read commit history (treating as no commits):", error);
+      return { ok: false, reason: 'no-commits' };
+    }
     if (mainCommits.length === 0) {
-      return null;
+      return { ok: false, reason: 'no-commits' };
     }
 
     const headCommitHash = await runGit(repoPath, ["rev-parse", "HEAD"]);
     const headTree = await getCommitTree(repoPath, headCommitHash);
 
     if (!headTree) {
-      return null;
+      return { ok: false, reason: 'no-head-tree' };
     }
 
     // Build committed AI changes first
@@ -790,11 +802,29 @@ export async function buildHistory(repoPath: string | undefined): Promise<Histor
     );
 
     return {
-      id: headCommitHash || "WORKING_DIR",
-      files: groupChangesByFile(deduplicateAILines(userConsumed)),
+      ok: true,
+      history: {
+        id: headCommitHash || "WORKING_DIR",
+        files: groupChangesByFile(deduplicateAILines(userConsumed)),
+      },
     };
   } catch (error) {
     console.error("Error building history:", error);
-    return null;
+    return { ok: false, reason: 'build-error' };
+  }
+}
+
+export function describeBuildHistoryFailure(reason: BuildHistoryFailureReason): string {
+  switch (reason) {
+    case 'not-a-git-repo':
+      return 'AI Blame: This needs to be a git repository.';
+    case 'no-commits':
+      return 'AI Blame: This repository has no commits yet.';
+    case 'no-repo-path':
+      return 'AI Blame: No repository found for the current workspace.';
+    case 'no-head-tree':
+    case 'build-error':
+    default:
+      return 'AI Blame: Failed to build history.';
   }
 }

--- a/vscode-extension/src/history/types.ts
+++ b/vscode-extension/src/history/types.ts
@@ -64,6 +64,12 @@ export type History = z.infer<typeof historySchema>;
 export type TaskletMessage = z.infer<typeof taskletMessage>
 export type TaskletQuestion = z.infer<typeof taskletQuestion>
 
+export type BuildHistoryFailureReason = 'no-repo-path' | 'not-a-git-repo' | 'no-commits' | 'no-head-tree' | 'build-error';
+
+export type BuildHistoryResult =
+  | { ok: true; history: History }
+  | { ok: false; reason: BuildHistoryFailureReason };
+
 export interface CommitInfo {
   hash: string;
   authorEmail: string;

--- a/vscode-extension/src/hookAgentPluginCheck.ts
+++ b/vscode-extension/src/hookAgentPluginCheck.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { homedir } from 'os';
 import { spawn, execSync } from 'child_process';
+import { clearFailureCooldown, notifyFailureOnce } from './failureCooldown';
 
 // Claude Code and Codex both install via merging a hooks config JSON (unlike
 // OpenCode's single-file-drop plugin — see pluginCheck.ts), so this is one
@@ -18,14 +19,6 @@ interface HookAgentConfig {
   postToolUseMatcher: string;
   failureCooldownKey: string;
 }
-
-// A failed install (e.g. Bun missing) shouldn't be retried on every single
-// activation — that would spam an error message the user can't act on
-// immediately. But it also can't be a permanent skip, or a user who fixes
-// the underlying problem (installs Bun) would never get auto-installed,
-// silently defeating the daily re-check in extension.ts. So failures get a
-// cooldown, not a permanent flag.
-const FAILURE_RETRY_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 
 const AGENTS: HookAgentConfig[] = [
   {
@@ -148,29 +141,34 @@ function installHooks(agent: HookAgentConfig, scriptPath: string, bunPath: strin
 // just happened, and an error notification if it fails — neither requires a
 // click to dismiss or to proceed.
 async function checkAgent(context: vscode.ExtensionContext, agent: HookAgentConfig): Promise<void> {
-  const lastFailureAt = context.globalState.get<number>(agent.failureCooldownKey);
-  if (lastFailureAt && Date.now() - lastFailureAt < FAILURE_RETRY_COOLDOWN_MS) { return; }
-
   const scriptPath = path.join(agent.installDir, agent.hookScriptFilename);
   const existingBunPath = resolveBunPath();
   if (existingBunPath && fs.existsSync(scriptPath) && isAlreadyConfigured(agent, scriptPath, existingBunPath)) {
+    await clearFailureCooldown(context.globalState, agent.failureCooldownKey);
+    return;
+  }
+
+  if (!existingBunPath) {
+    await notifyFailureOnce(context.globalState, agent.failureCooldownKey, () => {
+      vscode.window.showErrorMessage(
+        `Failed to install Tracybot ${agent.displayName} plugin: Bun is required to run this plugin. Install it from https://bun.sh — Tracybot will pick it up automatically.`
+      );
+    });
     return;
   }
 
   try {
-    if (!existingBunPath) {
-      throw new Error('Bun is required to run this plugin. Install it from https://bun.sh — Tracybot will pick it up automatically.');
-    }
-
     const installedScriptPath = await downloadHookScript(agent);
     installHooks(agent, installedScriptPath, existingBunPath);
 
+    await clearFailureCooldown(context.globalState, agent.failureCooldownKey);
     vscode.window.showInformationMessage(`Tracybot: ${agent.displayName} plugin installed.`);
   } catch (error) {
-    await context.globalState.update(agent.failureCooldownKey, Date.now());
-    vscode.window.showErrorMessage(
-      `Failed to install Tracybot ${agent.displayName} plugin: ${error instanceof Error ? error.message : String(error)}`
-    );
+    await notifyFailureOnce(context.globalState, agent.failureCooldownKey, () => {
+      vscode.window.showErrorMessage(
+        `Failed to install Tracybot ${agent.displayName} plugin: ${error instanceof Error ? error.message : String(error)}`
+      );
+    });
   }
 }
 

--- a/vscode-extension/src/hookAgentPluginCheck.ts
+++ b/vscode-extension/src/hookAgentPluginCheck.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import { homedir } from 'os';
 import { spawn, execSync } from 'child_process';
 import { clearFailureCooldown, notifyFailureOnce } from './failureCooldown';
+import { getBunInstallCommand } from './bunInstall';
 
 // Claude Code and Codex both install via merging a hooks config JSON (unlike
 // OpenCode's single-file-drop plugin — see pluginCheck.ts), so this is one
@@ -62,6 +63,19 @@ function resolveBunPath(): string | undefined {
     const fallback = path.join(homedir(), '.bun', 'bin', 'bun');
     return fs.existsSync(fallback) ? fallback : undefined;
   }
+}
+
+// Runs Bun's own official installer in a visible integrated terminal — not a
+// silent background process — so the user sees the script's own output and
+// it runs in their normal shell environment, matching how they'd run it
+// themselves. Deliberately doesn't try to detect completion or auto-reverify:
+// the terminal is async/interactive, and checkHookBasedAgents already
+// re-checks on every activation/repo-open, so the next one picks it up on
+// its own once Bun is actually installed — no extra wiring needed here.
+function installBun(): void {
+  const terminal = vscode.window.createTerminal('Install Bun');
+  terminal.sendText(getBunInstallCommand());
+  terminal.show();
 }
 
 // undefined = file doesn't exist yet (fine, starts empty).
@@ -149,10 +163,12 @@ async function checkAgent(context: vscode.ExtensionContext, agent: HookAgentConf
   }
 
   if (!existingBunPath) {
-    await notifyFailureOnce(context.globalState, agent.failureCooldownKey, () => {
-      vscode.window.showErrorMessage(
-        `Failed to install Tracybot ${agent.displayName} plugin: Bun is required to run this plugin. Install it from https://bun.sh — Tracybot will pick it up automatically.`
+    await notifyFailureOnce(context.globalState, agent.failureCooldownKey, async () => {
+      const action = await vscode.window.showErrorMessage(
+        `Failed to install Tracybot ${agent.displayName} plugin: Bun is required to run this plugin.`,
+        'Install Bun'
       );
+      if (action === 'Install Bun') { installBun(); }
     });
     return;
   }

--- a/vscode-extension/src/pluginCheck.ts
+++ b/vscode-extension/src/pluginCheck.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import { homedir } from 'os';
 import { spawn } from 'child_process';
 import { detectAnyHookAgent } from './hookAgentPluginCheck';
+import { clearFailureCooldown, notifyFailureOnce } from './failureCooldown';
 
 const PLUGIN_FILENAME = 'tracybot-oc.js';
 const PLUGIN_URL = 'https://github.com/TracyTeam/tracybot/releases/latest/download/tracybot-oc.js';
@@ -13,7 +14,6 @@ const SKIP_OPENCODE_MISSING_KEY = 'tracybot.skipOpencodeMissingCheck';
 // not a permanent skip, so a transient failure can't permanently defeat the
 // daily re-check in extension.ts.
 const INSTALL_FAILURE_COOLDOWN_KEY = 'tracybot.opencodeInstallFailureAt';
-const FAILURE_RETRY_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 
 function getGlobalPluginPath(): string {
   return path.join(homedir(), '.config', 'opencode', 'plugin', PLUGIN_FILENAME);
@@ -50,9 +50,6 @@ async function findOpencode(): Promise<boolean> {
 }
 
 export async function checkOpencode(context: vscode.ExtensionContext): Promise<void> {
-  const lastFailureAt = context.globalState.get<number>(INSTALL_FAILURE_COOLDOWN_KEY);
-  if (lastFailureAt && Date.now() - lastFailureAt < FAILURE_RETRY_COOLDOWN_MS) { return; }
-
   const opencodeAvailable = await findOpencode();
   if (!opencodeAvailable) {
     // Claude Code or Codex being installed is enough — this message (and its
@@ -77,10 +74,16 @@ export async function checkOpencode(context: vscode.ExtensionContext): Promise<v
     return;
   }
 
-  if (fs.existsSync(getGlobalPluginPath())) { return; }
+  if (fs.existsSync(getGlobalPluginPath())) {
+    await clearFailureCooldown(context.globalState, INSTALL_FAILURE_COOLDOWN_KEY);
+    return;
+  }
 
   const projectPath = getProjectPluginPath();
-  if (projectPath && fs.existsSync(projectPath)) { return; }
+  if (projectPath && fs.existsSync(projectPath)) {
+    await clearFailureCooldown(context.globalState, INSTALL_FAILURE_COOLDOWN_KEY);
+    return;
+  }
 
   // No confirmation prompt — same rationale as checkHookBasedAgents: installing
   // Tracybot already signals consent to trace AI changes, so this just installs
@@ -90,11 +93,13 @@ export async function checkOpencode(context: vscode.ExtensionContext): Promise<v
 
   try {
     await installPluginTo(path.dirname(installPath));
+    await clearFailureCooldown(context.globalState, INSTALL_FAILURE_COOLDOWN_KEY);
     vscode.window.showInformationMessage(`Tracybot: OpenCode plugin installed to ${installPath}.`);
   } catch (error) {
-    await context.globalState.update(INSTALL_FAILURE_COOLDOWN_KEY, Date.now());
-    vscode.window.showErrorMessage(
-      `Failed to install Tracybot OpenCode plugin: ${error instanceof Error ? error.message : String(error)}`
-    );
+    await notifyFailureOnce(context.globalState, INSTALL_FAILURE_COOLDOWN_KEY, () => {
+      vscode.window.showErrorMessage(
+        `Failed to install Tracybot OpenCode plugin: ${error instanceof Error ? error.message : String(error)}`
+      );
+    });
   }
 }

--- a/vscode-extension/src/research/researchModeCheck.ts
+++ b/vscode-extension/src/research/researchModeCheck.ts
@@ -31,6 +31,35 @@ const TIER_OPTIONS: TierPickItem[] = [
   },
 ];
 
+// Exported (rather than exporting TIER_OPTIONS directly) so the Manage
+// Research Mode command in extension.ts can offer the exact same tier
+// picker for a Change Tier action, without duplicating how it's presented.
+export async function pickResearchModeTier(): Promise<1 | 2 | 3 | undefined> {
+  const chosen = await vscode.window.showQuickPick(TIER_OPTIONS, {
+    title: 'Tracybot Research Mode — choose how much to share',
+    placeHolder: 'You can change or disable this anytime from the Research Mode status bar item',
+    ignoreFocusOut: true,
+  });
+  return chosen?.tier;
+}
+
+// Shared by the initial opt-in prompt and by re-enabling a previously
+// declined repo (see extension.ts's Manage Research Mode command) — both
+// are "turn Research Mode on and pick a tier," differing only in what
+// prompted it.
+export async function enableResearchModeForRepo(context: vscode.ExtensionContext, repoPath: string): Promise<void> {
+  // Dismissed (Escape) without picking — fall back to the most conservative
+  // tier rather than leaving some other prior value in place.
+  const tier = (await pickResearchModeTier()) ?? 1;
+
+  writeRepoConsent(repoPath, { decision: 'enabled', consentTier: tier });
+  getOrCreateParticipantId(context);
+
+  vscode.window.showInformationMessage(
+    `Research Mode enabled at Tier ${tier} for this repository. Change or disable it anytime from the Research Mode status bar item.`
+  );
+}
+
 // Per-repository, not machine-wide (see repoConsent.ts) — agreeing to share
 // one project's Tasklet history shouldn't silently enroll every other repo
 // opened afterward. Each repo gets asked once: "declined" and "enabled" are
@@ -49,22 +78,7 @@ export async function checkResearchModeConsent(context: vscode.ExtensionContext)
   );
 
   if (action === 'I agree to share my data') {
-    const chosen = await vscode.window.showQuickPick(TIER_OPTIONS, {
-      title: 'Tracybot Research Mode — choose how much to share',
-      placeHolder: 'You can change or disable this anytime from the Research Mode status bar item',
-      ignoreFocusOut: true,
-    });
-
-    // Dismissed (Escape) without picking — fall back to the most
-    // conservative tier rather than leaving some other prior value in place.
-    const tier = chosen?.tier ?? 1;
-
-    writeRepoConsent(repoPath, { decision: 'enabled', consentTier: tier });
-    getOrCreateParticipantId(context);
-
-    vscode.window.showInformationMessage(
-      `Research Mode enabled at Tier ${tier} for this repository. Change or disable it anytime from the Research Mode status bar item.`
-    );
+    await enableResearchModeForRepo(context, repoPath);
   } else if (action === 'Never for this repo') {
     writeRepoConsent(repoPath, { decision: 'declined' });
   }

--- a/vscode-extension/src/test/buildHistory.test.ts
+++ b/vscode-extension/src/test/buildHistory.test.ts
@@ -1,0 +1,49 @@
+/// <reference types="mocha" />
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execSync } from 'child_process';
+import { buildHistory } from '../history/buildHistory';
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'tracybot-build-history-'));
+}
+
+function initRepoWithCommit(dir: string): void {
+  execSync('git init -q', { cwd: dir });
+  execSync('git config user.email test@example.com', { cwd: dir });
+  execSync('git config user.name Test', { cwd: dir });
+  fs.writeFileSync(path.join(dir, 'a.txt'), 'hello\n');
+  execSync('git add a.txt && git commit -q -m init', { cwd: dir });
+}
+
+suite('buildHistory failure reasons', () => {
+  test('a non-git folder is reported as not-a-git-repo', async () => {
+    const dir = makeTempDir();
+    const result = await buildHistory(dir);
+    assert.strictEqual(result.ok, false);
+    if (!result.ok) { assert.strictEqual(result.reason, 'not-a-git-repo'); }
+  });
+
+  test('an initialized repo with zero commits is reported as no-commits', async () => {
+    const dir = makeTempDir();
+    execSync('git init -q', { cwd: dir });
+    const result = await buildHistory(dir);
+    assert.strictEqual(result.ok, false);
+    if (!result.ok) { assert.strictEqual(result.reason, 'no-commits'); }
+  });
+
+  test('a normal repo with a commit builds successfully', async () => {
+    const dir = makeTempDir();
+    initRepoWithCommit(dir);
+    const result = await buildHistory(dir);
+    assert.strictEqual(result.ok, true);
+  });
+
+  test('no repoPath is reported as no-repo-path', async () => {
+    const result = await buildHistory(undefined);
+    assert.strictEqual(result.ok, false);
+    if (!result.ok) { assert.strictEqual(result.reason, 'no-repo-path'); }
+  });
+});

--- a/vscode-extension/src/test/buildHistory.test.ts
+++ b/vscode-extension/src/test/buildHistory.test.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { execSync } from 'child_process';
-import { buildHistory } from '../history/buildHistory';
+import { buildHistory, describeBuildHistoryFailure } from '../history/buildHistory';
 
 function makeTempDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'tracybot-build-history-'));
@@ -45,5 +45,12 @@ suite('buildHistory failure reasons', () => {
     const result = await buildHistory(undefined);
     assert.strictEqual(result.ok, false);
     if (!result.ok) { assert.strictEqual(result.reason, 'no-repo-path'); }
+  });
+
+  test('no repoPath has an actionable AI Blame message', () => {
+    assert.strictEqual(
+      describeBuildHistoryFailure('no-repo-path'),
+      'AI Blame: No repository found for the current workspace.'
+    );
   });
 });

--- a/vscode-extension/src/test/researchMode.test.ts
+++ b/vscode-extension/src/test/researchMode.test.ts
@@ -10,16 +10,6 @@ suite('Research Mode integration', () => {
     assert.ok(ext!.isActive);
   });
 
-  test('tracybot.researchMode.enabled defaults to false', () => {
-    const enabled = vscode.workspace.getConfiguration('tracybot.researchMode').get<boolean>('enabled');
-    assert.strictEqual(enabled, false);
-  });
-
-  test('tracybot.researchMode.consentTier defaults to 1', () => {
-    const tier = vscode.workspace.getConfiguration('tracybot.researchMode').get<number>('consentTier');
-    assert.strictEqual(tier, 1);
-  });
-
   test('reviewResearchDigest command is registered', async () => {
     const commands = await vscode.commands.getCommands(true);
     assert.ok(
@@ -42,11 +32,12 @@ suite('Research Mode integration', () => {
     assert.strictEqual(rejected, undefined, `command rejected: ${String(rejected)}`);
   });
 
-  test('enabling researchMode.enabled does not throw (status bar update path)', async () => {
-    const config = vscode.workspace.getConfiguration('tracybot.researchMode');
-    await config.update('enabled', true, vscode.ConfigurationTarget.Global);
-    // Give the onDidChangeConfiguration listener a tick to run
-    await new Promise(resolve => setTimeout(resolve, 50));
-    await config.update('enabled', false, vscode.ConfigurationTarget.Global);
+  test('reviewResearchDigest palette title is "Tracybot: Manage Research Mode"', () => {
+    const ext = vscode.extensions.getExtension('TracyTeam.tracybot-extension');
+    assert.ok(ext, 'extension not found');
+    const commands: { command: string; title: string }[] = ext!.packageJSON.contributes.commands;
+    const entry = commands.find(c => c.command === 'tracybot-extension.reviewResearchDigest');
+    assert.ok(entry, 'reviewResearchDigest command not found in package.json');
+    assert.strictEqual(entry!.title, 'Tracybot: Manage Research Mode');
   });
 });

--- a/vscode-extension/src/tracyInitCheck.ts
+++ b/vscode-extension/src/tracyInitCheck.ts
@@ -3,12 +3,12 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { spawn } from 'child_process';
 import { getRepoPath } from './utils';
+import { clearFailureCooldown, notifyFailureOnce } from './failureCooldown';
 
 // A failed init (e.g. no Python) gets a cooldown, not a permanent skip — same
 // rationale as hookAgentPluginCheck.ts: a since-fixed problem (Python
 // installed later) should get picked up again, not stay silenced forever.
 const INIT_FAILURE_COOLDOWN_KEY = 'tracybot.tracyInitFailureAt';
-const FAILURE_RETRY_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 
 async function findPython(): Promise<string> {
   for (const cmd of ['python3', 'python']) {
@@ -32,23 +32,24 @@ async function findPython(): Promise<string> {
 // consent. Still surfaces a non-blocking notification once it's done, and an
 // error notification if it fails — neither requires a click to proceed.
 export async function checkTracyInit(context: vscode.ExtensionContext): Promise<void> {
-  const lastFailureAt = context.globalState.get<number>(INIT_FAILURE_COOLDOWN_KEY);
-  if (lastFailureAt && Date.now() - lastFailureAt < FAILURE_RETRY_COOLDOWN_MS) { return; }
-
   const repoPath = await getRepoPath();
   if (!repoPath) { return; }
 
   const tracyConfig = path.join(repoPath, '.git', 'tracybot', 'config');
-  if (fs.existsSync(tracyConfig)) { return; }
+  if (fs.existsSync(tracyConfig)) {
+    await clearFailureCooldown(context.globalState, INIT_FAILURE_COOLDOWN_KEY);
+    return;
+  }
 
   let python: string;
   try {
     python = await findPython();
   } catch (err) {
-    await context.globalState.update(INIT_FAILURE_COOLDOWN_KEY, Date.now());
-    vscode.window.showErrorMessage(
-      `Failed to initialize Tracybot in this repository: ${err instanceof Error ? err.message : String(err)}`
-    );
+    await notifyFailureOnce(context.globalState, INIT_FAILURE_COOLDOWN_KEY, () => {
+      vscode.window.showErrorMessage(
+        `Failed to initialize Tracybot in this repository: ${err instanceof Error ? err.message : String(err)}`
+      );
+    });
     return;
   }
 
@@ -63,11 +64,13 @@ export async function checkTracyInit(context: vscode.ExtensionContext): Promise<
       proc.on('error', reject);
     });
 
+    await clearFailureCooldown(context.globalState, INIT_FAILURE_COOLDOWN_KEY);
     vscode.window.showInformationMessage('Tracybot: repository initialized.');
   } catch (error) {
-    await context.globalState.update(INIT_FAILURE_COOLDOWN_KEY, Date.now());
-    vscode.window.showErrorMessage(
-      `Failed to initialize Tracybot in this repository: ${error instanceof Error ? error.message : String(error)}`
-    );
+    await notifyFailureOnce(context.globalState, INIT_FAILURE_COOLDOWN_KEY, () => {
+      vscode.window.showErrorMessage(
+        `Failed to initialize Tracybot in this repository: ${error instanceof Error ? error.message : String(error)}`
+      );
+    });
   }
 }


### PR DESCRIPTION
## Summary

Four fixes from Ranim's real-world testing feedback, root-caused this session. Each is its own commit.

### 1. Redesign the failure-cooldown logic (Bun / Python / OpenCode checks)

The cooldown check in `checkAgent`/`checkTracyInit`/`checkOpencode` was the first statement in each function, gating the *entire* retry attempt — including the cheap prerequisite check (Bun/Python CLI existence) that costs almost nothing to re-run. So if a user installed the missing dependency shortly after seeing the error, the extension wouldn't notice for up to 24h, even across a window reload, since the cooldown timestamp lives in `context.globalState`. This is almost certainly why Ranim's Claude Code hook never got installed, even after she installed Bun.

Extracted the three duplicated copies of this logic into a shared `failureCooldown.ts`: always re-run the check/attempt, only suppress the repeat error *notification* if the same failure was already shown within 24h, and always clear the cooldown on success.

### 2. Add an "Install Bun" button to the missing-Bun error

Previously plain text with a link to copy manually. Clicking the button now opens a visible integrated terminal running Bun's official installer for the current platform. Kept manual/click-driven rather than silently auto-run — installing a system-wide runtime and touching the shell profile is a bigger, more sensitive action than anything else this extension automates. Same conservative treatment intentionally **not** extended to Python in this PR (confirmed with the team) — Bun was the confirmed real-world pain point.

### 3. Add Change Tier / re-enable to the Research Mode management command

Before the per-repo consent migration, tier was a VS Code Setting anyone could edit anytime; removed with no replacement. Worse, the opt-in confirmation message still promised "change or disable it anytime from the status bar" — a promise the code didn't keep. A declined repo also had no way back in (declined was as terminal as enabled).

`reviewResearchDigest` already had no `"when"` clause, so it was already reachable via the Command Palette regardless of status-bar visibility — reworked its handler to branch on consent state (undecided → normal consent flow, declined → Re-enable/Keep Declined, enabled → adds a Change Tier action). Renamed the palette title to "Tracybot: Manage Research Mode". Also fixed `researchMode.test.ts`, which asserted on `tracybot.researchMode.*` Settings that no longer exist in `package.json` at all.

### 4. Distinguish "not a git repository" in the AI Blame error

`buildHistory()` collapsed at least 4 distinct failure reasons to a bare `return null`. Changed its return type to a `BuildHistoryResult` discriminated union carrying a specific reason, and added `describeBuildHistoryFailure()` for user-facing messages — `not-a-git-repo` now says "This needs to be a git repository," `no-commits` says "This repository has no commits yet."

Bonus fix found while doing this: `git log --reverse ...` exits 128 on a freshly-initialized repo with zero commits, which made the existing `mainCommits.length === 0` check dead code (it always fell into the generic catch-all instead). Fixed by wrapping `getMainCommits` in its own try/catch.

## Test plan

- [x] `npm run compile` / `npm run lint` clean throughout, and on the final branch tip
- [x] `npm run test:unit`: 53 tests passing (45 pre-existing + 5 new `failureCooldown.test.ts` + 3 new `bunInstall.test.ts`)
- [x] Isolated fake-vscode-module integration harnesses reproducing the actual reported bugs, run against the real compiled output:
  - The exact cooldown bug: Bun missing → single error → Bun installed moments later, still well within the old 24h window → install now succeeds immediately with no wait
  - "Install Bun" button opens a visible terminal with the correct platform-specific command
  - `reviewResearchDigest`'s real registered command handler across all three consent states (undecided/declined/enabled), including Change Tier persisting a new tier and Change Tier-dismissed leaving the existing tier untouched
  - `buildHistory()` against real git repos: non-git folder → `not-a-git-repo`, fresh `git init` with zero commits → `no-commits`, a repo with a real commit → success, `undefined` repoPath → `no-repo-path`
- [x] Added `src/test/buildHistory.test.ts` (vscode-test/Mocha, since `buildHistory.ts` transitively imports `vscode`) covering the same 4 scenarios for CI
