### PR TITLE
Fix pre-commit blocking commits after extension updates, and AI-to-AI attribution loss

### DIFF
--- a/tracking/hooks/pre-commit.py
+++ b/tracking/hooks/pre-commit.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import subprocess
 from pathlib import Path
@@ -17,6 +16,16 @@ def load_config(path):
     return config
 
 
+# This hook is a tracking convenience, not a policy gate — it must never be
+# able to block a real commit, no matter why the tracking step failed (a
+# stale config after an extension update, a missing script, a bug in
+# tracy.py itself, ...). Every failure path here prints a warning and exits
+# 0 instead of aborting the commit, unlike a normal validation hook.
+def warn_and_allow(message):
+    print(f"Warning: {message} — Tracybot snapshot skipped, commit proceeding.", file=sys.stderr)
+    sys.exit(0)
+
+
 def main():
     script_dir = Path(__file__).resolve().parent
     config_file = script_dir.parent / "tracybot" / "config"
@@ -25,10 +34,12 @@ def main():
     # CHECK CONFIG FILE
     # -------------------------------
     if not config_file.exists():
-        print(f"Error: Config file '{config_file}' not found.", file=sys.stderr)
-        sys.exit(1)
+        warn_and_allow(f"config file '{config_file}' not found")
 
-    config = load_config(config_file)
+    try:
+        config = load_config(config_file)
+    except OSError as e:
+        warn_and_allow(f"could not read config file: {e}")
 
     tracy_script = config.get("TRACY_SNAPSHOT_SCRIPT", "")
 
@@ -36,28 +47,26 @@ def main():
     # VALIDATE TRACY_SCRIPT
     # -------------------------------
     if not tracy_script:
-        print("Error: TRACY_SNAPSHOT_SCRIPT is not set in the config file.", file=sys.stderr)
-        sys.exit(1)
+        warn_and_allow("TRACY_SNAPSHOT_SCRIPT is not set in the config file")
 
     tracy_path = Path(tracy_script)
 
     if not tracy_path.exists():
-        print(f"Error: TRACY_SNAPSHOT_SCRIPT is set to '{tracy_script}' but the file does not exist.", file=sys.stderr)
-        sys.exit(1)
+        warn_and_allow(f"TRACY_SNAPSHOT_SCRIPT is set to '{tracy_script}' but the file does not exist")
 
     # -------------------------------
     # EXECUTE SCRIPT
     # -------------------------------
     try:
-        result = subprocess.run(
+        subprocess.run(
             [sys.executable, str(tracy_path), "--index-only"],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL
         )
-        sys.exit(result.returncode)
     except Exception as e:
-        print(f"Error executing Tracy script: {e}", file=sys.stderr)
-        sys.exit(1)
+        print(f"Warning: error executing Tracy script: {e} — commit proceeding.", file=sys.stderr)
+
+    sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/vscode-extension/src/history/buildHistory.ts
+++ b/vscode-extension/src/history/buildHistory.ts
@@ -390,9 +390,17 @@ async function extractSnapshot(
     Array.from(fileChangesMap.keys()).map(async (filePath) => {
       const hunks = fileChangesMap.get(filePath) || [];
 
-      // Only include lines from significant hunks
-      // This handles User->AI: if AI made insignificant changes, don't attribute those lines to AI
-      const significantHunks = hunks.filter(h => h.isSignificant);
+      // Only filter by significance when diffing against non-AI content
+      // (the real User->AI case). chain[0] is the last real, on-branch
+      // commit (pushed by getTracyChain() before it stops walking), so the
+      // first AI edit is at index 1, not 0 — "index > 0" alone isn't
+      // enough. Skipping the filter for AI->AI hops matters because a
+      // hunk diffed against the AI's OWN prior edit is very often
+      // textually close to it (small follow-up prompts, or just the
+      // unchanged surrounding context dominating the score), which isn't
+      // the "insignificant" case this filter exists to catch.
+      const diffsAgainstPriorAiEdit = index > 0 && isAiChange(chain[index - 1]);
+      const significantHunks = diffsAgainstPriorAiEdit ? hunks : hunks.filter(h => h.isSignificant);
       const linesAtSnapshot: number[] = [];
       for (const hunk of significantHunks) {
         for (let i = 0; i < hunk.newCount; i++) {

--- a/vscode-extension/src/test/buildHistory.test.ts
+++ b/vscode-extension/src/test/buildHistory.test.ts
@@ -54,3 +54,158 @@ suite('buildHistory failure reasons', () => {
     );
   });
 });
+
+// Builds a real hidden tracy-local commit on top of `parent`, matching the
+// exact shape claude-code-plugin/tracy.py produces: subject line is a bare
+// tasklet id, body is the JSON turn record, author/committer is the agent.
+function commitAiEdit(dir: string, parentHash: string, taskletId: string, sessionId: string, prompt: string, timestamp: number): string {
+  const tree = execSync('git write-tree', { cwd: dir, encoding: 'utf8' }).trim();
+  const body = JSON.stringify({
+    id: taskletId,
+    sessionId,
+    source: 'claude-code',
+    model: 'anthropic/claude-sonnet-5',
+    prompt,
+    response: `Did: ${prompt}`,
+    promptCreatedAt: timestamp,
+    responseCompletedAt: timestamp,
+  });
+  const message = `${taskletId}\n\n${body}`;
+  const commit = execSync(`git commit-tree ${tree} -p ${parentHash}`, {
+    cwd: dir,
+    input: message,
+    encoding: 'utf8',
+    env: { ...process.env, GIT_AUTHOR_NAME: 'claude-code', GIT_AUTHOR_EMAIL: 'claude-code', GIT_COMMITTER_NAME: 'claude-code', GIT_COMMITTER_EMAIL: 'claude-code' },
+  }).trim();
+  return commit;
+}
+
+suite('buildHistory significance filtering across a tracy-local chain', () => {
+  test('a second, textually-similar AI edit to a previously-untouched line still gets attributed', async () => {
+    const dir = makeTempDir();
+    execSync('git init -q', { cwd: dir });
+    execSync('git config user.email test@example.com', { cwd: dir });
+    execSync('git config user.name Test', { cwd: dir });
+
+    const filePath = path.join(dir, 'app.py');
+    fs.writeFileSync(filePath, [
+      'def calculate_total(items):',
+      '    total = 0',
+      '    for item in items:',
+      '        total += item.price * item.quantity',
+      '    if len(items) > 10:',
+      '        total *= 0.9',
+      '    return total',
+      '',
+    ].join('\n'));
+    execSync('git add app.py && git commit -q -m init', { cwd: dir });
+    const baseCommit = execSync('git rev-parse HEAD', { cwd: dir, encoding: 'utf8' }).trim();
+
+    // AI edit 1: add a docstring (an insertion, untouched by edit 2 below)
+    fs.writeFileSync(filePath, [
+      'def calculate_total(items):',
+      '    """Calculate the total price for a list of cart items."""',
+      '    total = 0',
+      '    for item in items:',
+      '        total += item.price * item.quantity',
+      '    if len(items) > 10:',
+      '        total *= 0.9',
+      '    return total',
+      '',
+    ].join('\n'));
+    execSync('git add app.py', { cwd: dir });
+    const commit1 = commitAiEdit(dir, baseCommit, 'tasklet-1', 'sess1', 'add a docstring', 1000);
+
+    // AI edit 2: a tiny, textually-similar follow-up to a DIFFERENT,
+    // previously-untouched line (> 10 -> >= 10) — realistic "iterate on
+    // it" prompt. Before the fix, this got silently dropped: the diff
+    // hunk here is nearly identical to what was already there, and the
+    // old code applied the same "insignificant -> don't attribute"
+    // filter used for User->AI transitions to this AI->AI transition too.
+    fs.writeFileSync(filePath, [
+      'def calculate_total(items):',
+      '    """Calculate the total price for a list of cart items."""',
+      '    total = 0',
+      '    for item in items:',
+      '        total += item.price * item.quantity',
+      '    if len(items) >= 10:',
+      '        total *= 0.9',
+      '    return total',
+      '',
+    ].join('\n'));
+    execSync('git add app.py', { cwd: dir });
+    const commit2 = commitAiEdit(dir, commit1, 'tasklet-2', 'sess1', 'actually make it >= not just >', 2000);
+
+    execSync(`git update-ref refs/tracy-local/chain-1 ${commit2}`, { cwd: dir });
+    execSync('git config tracy.current-id chain-1', { cwd: dir });
+    // Leave the working file as edit 2's content (real, uncommitted AI
+    // edits), but reset HEAD/index back to the base commit — matches a
+    // real session where nothing has been `git commit`-ed yet.
+    execSync(`git reset -q --mixed ${baseCommit}`, { cwd: dir });
+
+    const result = await buildHistory(dir);
+    assert.strictEqual(result.ok, true);
+    if (!result.ok) { return; }
+
+    const file = result.history.files.find(f => f.path === 'app.py');
+    assert.ok(file, 'app.py should appear in history');
+    const tasklet1 = file!.tasklets.find(t => t.taskletId === 'tasklet-1');
+    const tasklet2 = file!.tasklets.find(t => t.taskletId === 'tasklet-2');
+
+    assert.ok(tasklet2, 'the second AI edit must still be attributed, not silently dropped');
+    assert.ok(tasklet2!.lines.length > 0, 'the second AI edit must own a live line, not just a ghost one');
+    assert.ok(
+      !tasklet1 || !tasklet1.lines.some(l => tasklet2!.lines.includes(l)),
+      'the two edits touch different lines here, so there should be no overlapping live-line claim'
+    );
+  });
+
+  test('a tiny first AI edit that nearly reverts to the user\'s original code is still filtered out', async () => {
+    const dir = makeTempDir();
+    execSync('git init -q', { cwd: dir });
+    execSync('git config user.email test@example.com', { cwd: dir });
+    execSync('git config user.name Test', { cwd: dir });
+
+    const filePath = path.join(dir, 'app.py');
+    fs.writeFileSync(filePath, [
+      'def calculate_total(items):',
+      '    total = 0',
+      '    if len(items) > 10:',
+      '        total *= 0.9',
+      '    return total',
+      '',
+    ].join('\n'));
+    execSync('git add app.py && git commit -q -m init', { cwd: dir });
+    const baseCommit = execSync('git rev-parse HEAD', { cwd: dir, encoding: 'utf8' }).trim();
+
+    // A single, near-identical AI "edit" (> 10 -> >= 10) as the FIRST
+    // snapshot in a fresh chain — diffing against the user's own
+    // original code. This is the actual User->AI case the significance
+    // filter exists for, and must still be suppressed.
+    fs.writeFileSync(filePath, [
+      'def calculate_total(items):',
+      '    total = 0',
+      '    if len(items) >= 10:',
+      '        total *= 0.9',
+      '    return total',
+      '',
+    ].join('\n'));
+    execSync('git add app.py', { cwd: dir });
+    const commit1 = commitAiEdit(dir, baseCommit, 'tasklet-idx0', 'sess2', 'tiny tweak', 1000);
+
+    execSync(`git update-ref refs/tracy-local/chain-idx0 ${commit1}`, { cwd: dir });
+    execSync('git config tracy.current-id chain-idx0', { cwd: dir });
+    execSync(`git reset -q --mixed ${baseCommit}`, { cwd: dir });
+
+    const result = await buildHistory(dir);
+    assert.strictEqual(result.ok, true);
+    if (!result.ok) { return; }
+
+    const file = result.history.files.find(f => f.path === 'app.py');
+    const tasklet = file?.tasklets.find(t => t.taskletId === 'tasklet-idx0');
+    assert.ok(
+      !tasklet || tasklet.lines.length === 0,
+      'a tiny User->AI edit must not be credited to AI as a live line'
+    );
+  });
+});

--- a/vscode-extension/src/tracyInitCheck.ts
+++ b/vscode-extension/src/tracyInitCheck.ts
@@ -26,6 +26,23 @@ async function findPython(): Promise<string> {
   throw new Error('Python is not installed or not available.');
 }
 
+// init.py writes TRACY_SNAPSHOT_SCRIPT as an absolute path into *this*
+// extension version's own directory (assets/tracking/tracy.py). VS Code
+// deletes the previous version's directory on every auto-update, so a repo
+// initialized under an older version silently ends up pointing at a script
+// that no longer exists. A missing config file's mere *existence* isn't
+// enough to call a repo "initialized" — the target it points to has to
+// still be there, or every future commit hook run fails to find it.
+function isTracySnapshotScriptValid(tracyConfigPath: string): boolean {
+  try {
+    const content = fs.readFileSync(tracyConfigPath, 'utf8');
+    const match = content.match(/^TRACY_SNAPSHOT_SCRIPT=(.+)$/m);
+    return !!match && fs.existsSync(match[1].trim());
+  } catch {
+    return false;
+  }
+}
+
 // No confirmation prompt — same rationale as hookAgentPluginCheck.ts:
 // installing Tracybot is itself the user's opt-in to AI change tracing, so
 // auto-initializing a detected repository is redundant friction, not extra
@@ -36,7 +53,7 @@ export async function checkTracyInit(context: vscode.ExtensionContext): Promise<
   if (!repoPath) { return; }
 
   const tracyConfig = path.join(repoPath, '.git', 'tracybot', 'config');
-  if (fs.existsSync(tracyConfig)) {
+  if (fs.existsSync(tracyConfig) && isTracySnapshotScriptValid(tracyConfig)) {
     await clearFailureCooldown(context.globalState, INIT_FAILURE_COOLDOWN_KEY);
     return;
   }


### PR DESCRIPTION
## Summary

Two independent fixes, both from real-world reports by Ranim.

### 1. Pre-commit hook blocking every commit after an extension update

After Tracybot auto-updated from 1.3.4 to 1.3.5, `git commit` started failing outright:

```
Error: TRACY_SNAPSHOT_SCRIPT is set to '/Users/ranimkhojah/.vscode/extensions/tracyteam.tracybot-extension-1.3.4/assets/tracking/tracy.py' but the file does not exist.
```

**Root cause:** `init.py` writes `TRACY_SNAPSHOT_SCRIPT` into `.git/tracybot/config` as an absolute path into *that specific extension version's own directory*. VS Code deletes the previous version's directory on every auto-update, so any repo initialized under an older version silently ends up pointing at a script that no longer exists. `tracking/hooks/pre-commit.py` treated that as a hard failure (`sys.exit(1)`), which blocks the commit outright — for any reason the script becomes unavailable, not just this one. Since Tracybot ships on the Marketplace and auto-updates by default, every user who has ever run `init.py` will hit this the next time the extension updates.

Two changes, both needed:

- **`pre-commit.py`**: this hook is a tracking convenience, not a policy gate — it must never be able to block a real commit. Every failure path (missing config, missing script, `tracy.py` itself erroring) now prints a warning to stderr and exits 0 instead of aborting the commit.
- **`tracyInitCheck.ts`**: `checkTracyInit()` previously treated the mere *existence* of `.git/tracybot/config` as "already initialized, nothing to do," never validating that `TRACY_SNAPSHOT_SCRIPT` still points somewhere real. Added `isTracySnapshotScriptValid()` so a stale config is treated as "not really initialized," falling through to the existing (already idempotent, non-interactive when given an explicit repo path) `init.py` re-run — which also matters because `init.py` copies `pre-commit.py`'s *source* into `.git/hooks/pre-commit.tracy` at init time, so this PR's own never-block fix only reaches already-initialized repos once they get re-initialized.

### 2. AI attribution dropped for iterative AI-to-AI edits

Ranim also reported that a follow-up AI prompt to refine a line the AI had *just* edited would sometimes not show up in AI Blame at all — only the first prompt's edit was attributed.

**Root cause:** `extractSnapshot()` filters every diff hunk by BLEU-similarity ("significance") before attributing it to AI, to handle the User→AI case: don't credit AI for a tiny edit that's nearly identical to what the user already wrote. But `getTracyChain()` pushes the chain's boundary commit (the last real, on-branch commit) as `chain[0]` before it stops walking, so the *first* AI edit actually sits at `chain[1]` — and every later AI edit in the same chain was diffed with this same filter, which then also suppressed ordinary AI-to-AI iteration (a small follow-up prompt) any time the new text was textually close to what the AI itself just wrote, silently dropping that edit's attribution entirely.

Fix: only apply the significance filter when the snapshot isn't diffing against a prior AI-authored snapshot in the same chain — that's the only case with real authorship ambiguity left to resolve.

## Test plan

- [x] `npm run compile` / `npm run lint` / `npm run test:unit` (53 tests) clean
- [x] `pre-commit.py` run directly across four scenarios — no config file, config pointing at a missing script (Ranim's exact case), a script that runs successfully, and a script that itself exits non-zero — all now exit 0 (previously all but the success case exited 1)
- [x] Isolated fake-vscode-module harness for `checkTracyInit`: a stale config (script path doesn't exist) is detected and triggers a repair that rewrites the config to a fresh, existing path; an already-valid config is left alone with no redundant re-init (avoids unnecessary `init.py` overhead — e.g. its remote fetch/sync step — on every activation)
- [x] Real git-based tracy-local chain tests (`buildHistory.test.ts`) covering both the AI-to-AI iteration case (both prompts now correctly attributed) and the User→AI regression case (a tiny first AI edit is still correctly filtered)
