### PR TITLE
Fix earlier prompts vanishing when a later prompt re-edits the same line

### DIFF
--- a/vscode-extension/src/history/buildHistory.ts
+++ b/vscode-extension/src/history/buildHistory.ts
@@ -457,20 +457,43 @@ async function extractSnapshot(
 
       let filteredLines = lines;
       if (dropOverriddenLines) {
-        const userDiffMap = await getDiff(
+        // Only check for genuine overrides in the gap AFTER this chain's
+        // own last entry — not the whole span from this snapshot to
+        // targetTree. A line touched by a LATER entry WITHIN this same
+        // chain is already represented by that entry's own Change object
+        // (from this same chain.map() call in extractChangesFromSnapshotChain)
+        // and gets correctly demoted to a ghost line by
+        // deduplicateAILines() afterward; dropping it here too would just
+        // mean deduplicateAILines() never gets the chance, and if this
+        // snapshot's ENTIRE line set gets dropped this way, the whole
+        // Change disappears with no ghost trace at all (see
+        // dropOverriddenLines's own doc comment above, and Ranim's
+        // report this fixes: a prompt vanishing from a line's history the
+        // moment a later prompt edits that line again — including after
+        // the whole chain gets finalized into one commit).
+        // What's left, past the chain's own tip, is genuinely untracked —
+        // e.g. a last-minute manual edit made right before `git commit`
+        // — and there's no other Change object that will ever represent
+        // it, so it has to be caught here.
+        const chainTipTree = chain[chain.length - 1].treeHash;
+        const residualDiffMap = await getDiff(
           repoPath,
-          snapshot.treeHash,
+          chainTipTree,
           targetTree,
           filePath
         );
 
-        const userHunks = userDiffMap.get(filePath) || [];
+        const residualHunks = residualDiffMap.get(filePath) || [];
 
+        // lines is already mapped into targetTree's coordinate space
+        // (mapLinesToTree's output), so it must be compared against
+        // these hunks' NEW side (also targetTree-relative) — not their
+        // OLD side, which is chainTipTree-relative.
         filteredLines = lines.filter((line) => {
-          return !userHunks.some((hunk) => {
+          return !residualHunks.some((hunk) => {
             return (
-              line >= hunk.oldStart &&
-              line < hunk.oldStart + hunk.oldCount
+              line >= hunk.newStart &&
+              line < hunk.newStart + hunk.newCount
             );
           });
         });

--- a/vscode-extension/src/history/buildHistory.ts
+++ b/vscode-extension/src/history/buildHistory.ts
@@ -361,7 +361,29 @@ async function extractSnapshot(
   baseTree: string,
   index: number,
   targetTree: string | "WORKING_DIR",
-  originCommit?: CommitInfo
+  originCommit?: CommitInfo,
+  // Whether to drop (not just live-deprioritize) any line this snapshot
+  // touched that's ALSO touched again somewhere between here and
+  // targetTree — and to discard the whole Change if nothing survives.
+  // True (default) is correct when targetTree can include content this
+  // function has no other visibility into (e.g. buildCommittedHistory's
+  // call, where targetTree is a real finalized commit that could include
+  // last-minute edits made outside any tracked AI turn — there's no other
+  // Change object that will ever represent that override, so it must be
+  // caught here or never at all).
+  // False is for buildUncommittedChanges's call, where targetTree is
+  // always exactly the tracy-local chain's own last snapshot — so
+  // "touched again before targetTree" only ever means "a later entry in
+  // this very chain", which already gets its own Change object here and
+  // which deduplicateAILines() already demotes correctly to a ghost line
+  // instead of erasing outright. Dropping the lines (and potentially the
+  // whole Change) here first means deduplicateAILines never gets the
+  // chance to do that: a line edited by an earlier prompt and then
+  // touched again by a later prompt in the same in-progress session
+  // vanishes from history entirely instead of showing up as "previously
+  // touched by" — see Ranim's report of a prompt disappearing from a
+  // line's history after a later prompt edited it again.
+  dropOverriddenLines = true
 ): Promise<Change[]> {
   if (!isAiChange(snapshot)) {
     return [];
@@ -433,23 +455,26 @@ async function extractSnapshot(
         linesAtSnapshot
       );
 
-      const userDiffMap = await getDiff(
-        repoPath,
-        snapshot.treeHash,
-        targetTree,
-        filePath
-      );
+      let filteredLines = lines;
+      if (dropOverriddenLines) {
+        const userDiffMap = await getDiff(
+          repoPath,
+          snapshot.treeHash,
+          targetTree,
+          filePath
+        );
 
-      const userHunks = userDiffMap.get(filePath) || [];
+        const userHunks = userDiffMap.get(filePath) || [];
 
-      const filteredLines = lines.filter((line) => {
-        return !userHunks.some((hunk) => {
-          return (
-            line >= hunk.oldStart &&
-            line < hunk.oldStart + hunk.oldCount
-          );
+        filteredLines = lines.filter((line) => {
+          return !userHunks.some((hunk) => {
+            return (
+              line >= hunk.oldStart &&
+              line < hunk.oldStart + hunk.oldCount
+            );
+          });
         });
-      });
+      }
 
       if (filteredLines.length > 0) {
         return {
@@ -612,7 +637,15 @@ async function buildUncommittedChanges(
         tracyChain,
         headTree,
         index,
-        lastTracyTip
+        lastTracyTip,
+        undefined,
+        // targetTree here is always exactly this chain's own last
+        // snapshot, so anything that "overrides" a line before targetTree
+        // is necessarily a later entry in this same chain — which gets
+        // its own Change object and which deduplicateAILines() already
+        // demotes correctly to a ghost line. See extractSnapshot's own
+        // comment on this parameter.
+        false
       )
     )
   );

--- a/vscode-extension/src/test/buildHistory.test.ts
+++ b/vscode-extension/src/test/buildHistory.test.ts
@@ -293,6 +293,156 @@ suite('buildHistory keeps earlier prompts as history when a later prompt re-edit
     assert.ok(tasklet1!.ghostLines.length > 0, 'prompt 1 should be recorded as ghost/history for this line');
     assert.ok(tasklet2!.ghostLines.length > 0, 'prompt 2 should be recorded as ghost/history for this line');
   });
+
+  test('the same three-prompt history survives once the user commits, finalizing the whole chain', async () => {
+    // The previous test's fix only covered the in-progress (uncommitted)
+    // chain, via buildUncommittedChanges's own direct call to
+    // extractSnapshot. But extractChangesFromSnapshotChain (used by
+    // buildCommittedHistory once the user runs `git commit`, finalizing
+    // the whole chain into one real commit) calls extractSnapshot too,
+    // with dropOverriddenLines left at its default — so the exact same
+    // "later entry in the same chain overrides an earlier one, and the
+    // earlier one's Change gets dropped instead of ghosted" bug still
+    // applied there, just one step later in the workflow: the history
+    // would look fine right up until the user committed, at which point
+    // it broke again.
+    const dir = makeTempDir();
+    execSync('git init -q', { cwd: dir });
+    execSync('git config user.email test@example.com', { cwd: dir });
+    execSync('git config user.name Test', { cwd: dir });
+
+    const filePath = path.join(dir, 'app.py');
+    fs.writeFileSync(filePath, [
+      'def process(order):',
+      '    # placeholder',
+      '    return None',
+      '',
+    ].join('\n'));
+    execSync('git add app.py && git commit -q -m init', { cwd: dir });
+    const baseCommit = execSync('git rev-parse HEAD', { cwd: dir, encoding: 'utf8' }).trim();
+
+    fs.writeFileSync(filePath, [
+      'def process(order):',
+      '    total = calculate_shipping_cost(order)',
+      '    return None',
+      '',
+    ].join('\n'));
+    execSync('git add app.py', { cwd: dir });
+    const commit1 = commitAiEdit(dir, baseCommit, 'tasklet-1', 'sess1', 'add shipping cost calculation', 1000);
+
+    fs.writeFileSync(filePath, [
+      'def process(order):',
+      '    total = compute_shipping_cost(order)',
+      '    return None',
+      '',
+    ].join('\n'));
+    execSync('git add app.py', { cwd: dir });
+    const commit2 = commitAiEdit(dir, commit1, 'tasklet-2', 'sess1', 'rename calculate to compute', 2000);
+
+    fs.writeFileSync(filePath, [
+      'def process(order):',
+      '    total = compute_cost(order)',
+      '    return None',
+      '',
+    ].join('\n'));
+    execSync('git add app.py', { cwd: dir });
+    const commit3 = commitAiEdit(dir, commit2, 'tasklet-3', 'sess1', 'remove shipping from the function name', 3000);
+
+    execSync(`git update-ref refs/tracy-local/aaaa1111 ${commit3}`, { cwd: dir });
+    execSync('git config tracy.current-id aaaa1111', { cwd: dir });
+
+    // The user commits, finalizing the whole chain into one real commit.
+    execSync('git add -A && git commit -q -am "shipping cost calc (AI assisted)"', { cwd: dir });
+    execSync('git notes add -m "tracy-id: aaaa1111" HEAD', { cwd: dir });
+    execSync(`git update-ref refs/tracy/aaaa1111 ${commit3}`, { cwd: dir });
+    // Finalizing clears the active-chain marker — it's no longer in progress.
+    execSync('git config --unset tracy.current-id', { cwd: dir });
+
+    const result = await buildHistory(dir);
+    assert.strictEqual(result.ok, true);
+    if (!result.ok) { return; }
+
+    const file = result.history.files.find(f => f.path === 'app.py');
+    assert.ok(file, 'app.py should appear in history');
+    const tasklet1 = file!.tasklets.find(t => t.taskletId === 'tasklet-1');
+    const tasklet2 = file!.tasklets.find(t => t.taskletId === 'tasklet-2');
+    const tasklet3 = file!.tasklets.find(t => t.taskletId === 'tasklet-3');
+
+    assert.ok(tasklet1, 'prompt 1 must still appear in history after the commit, not disappear entirely');
+    assert.ok(tasklet2, 'prompt 2 must still appear in history after the commit, not disappear entirely');
+    assert.ok(tasklet3, 'prompt 3 must be attributed');
+
+    assert.deepStrictEqual(tasklet1!.lines, [], 'prompt 1 should no longer own the live line');
+    assert.deepStrictEqual(tasklet2!.lines, [], 'prompt 2 should no longer own the live line');
+    assert.ok(tasklet3!.lines.length > 0, 'prompt 3 (the most recent edit) should own the live line');
+
+    assert.ok(tasklet1!.ghostLines.length > 0, 'prompt 1 should be recorded as ghost/history for this line');
+    assert.ok(tasklet2!.ghostLines.length > 0, 'prompt 2 should be recorded as ghost/history for this line');
+  });
+
+  test('a genuine manual edit made right before commit is still correctly excluded from AI attribution', async () => {
+    // Guards against overcorrecting the two tests above: the committed
+    // path's dropOverriddenLines check still needs to catch a REAL,
+    // untracked override — e.g. the user manually tweaks something right
+    // before running `git commit`, with no AI turn (and so no Change
+    // object) representing that edit at all. Only the gap strictly AFTER
+    // the tracy-local chain's own last snapshot should count for this;
+    // scoping it correctly is what the two tests above depend on too.
+    const dir = makeTempDir();
+    execSync('git init -q', { cwd: dir });
+    execSync('git config user.email test@example.com', { cwd: dir });
+    execSync('git config user.name Test', { cwd: dir });
+
+    const filePath = path.join(dir, 'app.py');
+    fs.writeFileSync(filePath, [
+      'def process(order):',
+      '    # placeholder',
+      '    return None',
+      '',
+    ].join('\n'));
+    execSync('git add app.py && git commit -q -m init', { cwd: dir });
+    const baseCommit = execSync('git rev-parse HEAD', { cwd: dir, encoding: 'utf8' }).trim();
+
+    fs.writeFileSync(filePath, [
+      'def process(order):',
+      '    total = calculate_shipping_cost(order)',
+      '    tax = calculate_tax(order)',
+      '    return total + tax',
+      '',
+    ].join('\n'));
+    execSync('git add app.py', { cwd: dir });
+    const commit1 = commitAiEdit(dir, baseCommit, 'tasklet-1', 'sess1', 'add shipping and tax calculation', 1000);
+
+    execSync(`git update-ref refs/tracy-local/aaaa1111 ${commit1}`, { cwd: dir });
+    execSync('git config tracy.current-id aaaa1111', { cwd: dir });
+
+    // Manually edit ONLY the tax line before committing — no AI turn
+    // represents this.
+    fs.writeFileSync(filePath, [
+      'def process(order):',
+      '    total = calculate_shipping_cost(order)',
+      '    tax = manually_fixed_tax_calc(order)',
+      '    return total + tax',
+      '',
+    ].join('\n'));
+    execSync('git add -A && git commit -q -am "shipping and tax calc (AI assisted, tax manually tweaked)"', { cwd: dir });
+    execSync('git notes add -m "tracy-id: aaaa1111" HEAD', { cwd: dir });
+    execSync(`git update-ref refs/tracy/aaaa1111 ${commit1}`, { cwd: dir });
+    execSync('git config --unset tracy.current-id', { cwd: dir });
+
+    const result = await buildHistory(dir);
+    assert.strictEqual(result.ok, true);
+    if (!result.ok) { return; }
+
+    const file = result.history.files.find(f => f.path === 'app.py');
+    const tasklet = file?.tasklets.find(t => t.taskletId === 'tasklet-1');
+    assert.ok(tasklet, 'the untouched lines should still be attributed');
+    assert.deepStrictEqual(
+      tasklet!.lines,
+      [2, 4],
+      'the manually-edited tax line (3) must not be credited to AI — only the untouched shipping and return lines should be'
+    );
+  });
 });
 
 suite('buildHistory does not blanket-credit a whole hunk to one tasklet', () => {

--- a/vscode-extension/src/test/buildHistory.test.ts
+++ b/vscode-extension/src/test/buildHistory.test.ts
@@ -210,6 +210,91 @@ suite('buildHistory significance filtering across a tracy-local chain', () => {
   });
 });
 
+suite('buildHistory keeps earlier prompts as history when a later prompt re-edits the same line', () => {
+  test('three consecutive prompts editing the same line all remain visible, with only the last one live', async () => {
+    // Ranim's report: editing one line with three consecutive prompts
+    // (add, then edit, then a small tweak) made the earlier prompts
+    // disappear from the line's history entirely, not just lose the live
+    // highlight. Root cause: extractSnapshot() dropped any line a
+    // snapshot's own edit didn't survive to the target tree — and
+    // discarded the WHOLE Change object if nothing survived — before
+    // deduplicateAILines() ever got a chance to demote it to a ghost line
+    // instead. That's the same "later prompt overrides earlier one"
+    // situation the committed-history path already handles correctly via
+    // ghost lines; the uncommitted, in-progress chain just never got to
+    // use that mechanism.
+    const dir = makeTempDir();
+    execSync('git init -q', { cwd: dir });
+    execSync('git config user.email test@example.com', { cwd: dir });
+    execSync('git config user.name Test', { cwd: dir });
+
+    const filePath = path.join(dir, 'app.py');
+    fs.writeFileSync(filePath, [
+      'def process(order):',
+      '    # placeholder',
+      '    return None',
+      '',
+    ].join('\n'));
+    execSync('git add app.py && git commit -q -m init', { cwd: dir });
+    const baseCommit = execSync('git rev-parse HEAD', { cwd: dir, encoding: 'utf8' }).trim();
+
+    // Prompt 1: adds the line.
+    fs.writeFileSync(filePath, [
+      'def process(order):',
+      '    total = calculate_shipping_cost(order)',
+      '    return None',
+      '',
+    ].join('\n'));
+    execSync('git add app.py', { cwd: dir });
+    const commit1 = commitAiEdit(dir, baseCommit, 'tasklet-1', 'sess1', 'add shipping cost calculation', 1000);
+
+    // Prompt 2: edits that same line.
+    fs.writeFileSync(filePath, [
+      'def process(order):',
+      '    total = compute_shipping_cost(order)',
+      '    return None',
+      '',
+    ].join('\n'));
+    execSync('git add app.py', { cwd: dir });
+    const commit2 = commitAiEdit(dir, commit1, 'tasklet-2', 'sess1', 'rename calculate to compute', 2000);
+
+    // Prompt 3: removes one word from it.
+    fs.writeFileSync(filePath, [
+      'def process(order):',
+      '    total = compute_cost(order)',
+      '    return None',
+      '',
+    ].join('\n'));
+    execSync('git add app.py', { cwd: dir });
+    const commit3 = commitAiEdit(dir, commit2, 'tasklet-3', 'sess1', 'remove shipping from the function name', 3000);
+
+    execSync(`git update-ref refs/tracy-local/chain-1 ${commit3}`, { cwd: dir });
+    execSync('git config tracy.current-id chain-1', { cwd: dir });
+    execSync(`git reset -q --mixed ${baseCommit}`, { cwd: dir });
+
+    const result = await buildHistory(dir);
+    assert.strictEqual(result.ok, true);
+    if (!result.ok) { return; }
+
+    const file = result.history.files.find(f => f.path === 'app.py');
+    assert.ok(file, 'app.py should appear in history');
+    const tasklet1 = file!.tasklets.find(t => t.taskletId === 'tasklet-1');
+    const tasklet2 = file!.tasklets.find(t => t.taskletId === 'tasklet-2');
+    const tasklet3 = file!.tasklets.find(t => t.taskletId === 'tasklet-3');
+
+    assert.ok(tasklet1, 'prompt 1 must still appear in history, not disappear entirely');
+    assert.ok(tasklet2, 'prompt 2 must still appear in history, not disappear entirely');
+    assert.ok(tasklet3, 'prompt 3 must be attributed');
+
+    assert.deepStrictEqual(tasklet1!.lines, [], 'prompt 1 should no longer own the live line');
+    assert.deepStrictEqual(tasklet2!.lines, [], 'prompt 2 should no longer own the live line');
+    assert.ok(tasklet3!.lines.length > 0, 'prompt 3 (the most recent edit) should own the live line');
+
+    assert.ok(tasklet1!.ghostLines.length > 0, 'prompt 1 should be recorded as ghost/history for this line');
+    assert.ok(tasklet2!.ghostLines.length > 0, 'prompt 2 should be recorded as ghost/history for this line');
+  });
+});
+
 suite('buildHistory does not blanket-credit a whole hunk to one tasklet', () => {
   test('a human commit bundling a tiny AI-line tweak with an unrelated adjacent comment only credits the AI line', async () => {
     const dir = makeTempDir();


### PR DESCRIPTION
## Summary

Ranim reported: editing one line with three consecutive prompts (add, then edit, then a small tweak) made the earlier prompts disappear from the line's history entirely — not just lose the live highlight, gone from the "previously touched by" dropdown too.

**Root cause:** `extractSnapshot()` computed a snapshot's attributed lines, then dropped any line that got touched again before the target tree, and discarded the WHOLE `Change` object if nothing survived — before `deduplicateAILines()` ever got a chance to run. `deduplicateAILines()` already handles exactly this situation correctly (demoting an overridden line to a ghost line instead of erasing it), but only for `Change` objects that actually reach it.

### Fix 1 — the in-progress (uncommitted) chain

For `buildUncommittedChanges`'s direct call to `extractSnapshot`, this pre-filtering is redundant with `deduplicateAILines()` by construction: its `targetTree` is always exactly the chain's own last snapshot, so anything that "overrides" a line before `targetTree` is necessarily a later entry in the same chain — which gets its own `Change` object anyway. Added a `dropOverriddenLines` parameter, `false` for this call site, letting `deduplicateAILines()` do the correct ghost conversion instead.

### Fix 2 — the same bug once the chain gets committed (self-review catch)

`extractChangesFromSnapshotChain` (used by `buildCommittedHistory` once the user runs `git commit`) calls `extractSnapshot` too, left at the default `dropOverriddenLines=true` — so the exact same bug still applied there: the history looked right immediately after several same-line prompts, right up until the user committed, at which point it broke again.

The `true` default is still genuinely needed for this path: `targetTree` there is a real finalized commit, which can include a last-minute manual edit made right before `git commit` with no AI turn (and so no `Change` object) representing it at all — that has to be caught somewhere.

Fixed by narrowing what counts as an "override" worth dropping for: only the gap strictly **after** the chain's own last snapshot, not the whole span from this snapshot to `targetTree`. A line touched by a later entry *within* the same chain already gets its own `Change` object and reaches `deduplicateAILines()` correctly; only what's left over past the chain's own tip is genuinely untracked. While rescoping this, also fixed the filter comparing mismatched tree coordinates (it compared an already-target-mapped line against the residual hunks' old/source side instead of their new/target side) — didn't affect the bug above, but was live and directly adjacent.

## Test plan

- [x] `npm run compile` / `npm run lint` / `npm run test:unit` (53 tests) clean
- [x] Real git-based repro matching Ranim's report exactly (uncommitted): three consecutive prompts editing the same line — all three now appear, first two as ghost/history, third as live
- [x] Same repro replayed through to a real `git commit` (previously broke again at commit time) — same correct result
- [x] Genuine untracked manual edit made right before commit: single-line case (whole Change correctly disappears) and multi-line case (only the manually-edited line excluded, untouched lines stay attributed)
- [x] Re-verified the AI-to-AI iteration (uncommitted) and cross-commit contested-line (committed propagation) scenarios are unaffected
